### PR TITLE
Fixed Rig_and_Attachments_Template.fbx Head Attachments

### DIFF
--- a/content/en-us/assets/modeling/meshes/reference-files/Rig_and_Attachments_Template.fbx
+++ b/content/en-us/assets/modeling/meshes/reference-files/Rig_and_Attachments_Template.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18faf9e7ba4937eaafdc3d23dcd71fc6eefdef64b2a00a3fba20bfccc5e43e9a
-size 260992
+oid sha256:40aac280a7161b651ed6674d14d2f44094ab170b960c3c9007f04cc12d286d3c
+size 116476


### PR DESCRIPTION
## Changes

Fixed the FaceCenter_Att, FaceFront_Att, Hair_Att, and Hat_Att being parented to the UpperTorso bone instead of the Head bone in Rig_and_Attachments_Template.fbx

![Rig_Attachments_Before_and_After](https://github.com/Roblox/creator-docs/assets/19847497/853d90b3-c3a5-43f1-b33e-9a975c528986)
