### PR TITLE
Fix UI animation typewriter

### DIFF
--- a/content/en-us/ui/animation.md
+++ b/content/en-us/ui/animation.md
@@ -543,7 +543,7 @@ The "typewriter" effect is ideal for `Class.TextLabel|TextLabels` that tell a st
 
    	-- Replace line break tags so grapheme loop will not miss those characters
    	displayText = displayText:gsub("<br%s*/>", "\n")
-    -- Remove RichText tags since char-by-char animation will break the tags
+    	-- Remove RichText tags since char-by-char animation will break the tags
    	displayText = displayText:gsub("<[^<>]->", "")
 
    	-- Set translated/modified text on parent

--- a/content/en-us/ui/animation.md
+++ b/content/en-us/ui/animation.md
@@ -553,7 +553,7 @@ The "typewriter" effect is ideal for `Class.TextLabel|TextLabels` that tell a st
    	for first, last in utf8.graphemes(displayText) do
    		index = index + 1
    		guiObject.MaxVisibleGraphemes = index
-   		wait(delayBetweenChars)
+   		task.wait(delayBetweenChars)
    	end
    end
 

--- a/content/en-us/ui/animation.md
+++ b/content/en-us/ui/animation.md
@@ -543,7 +543,7 @@ The "typewriter" effect is ideal for `Class.TextLabel|TextLabels` that tell a st
 
    	-- Replace line break tags so grapheme loop will not miss those characters
    	displayText = displayText:gsub("<br%s*/>", "\n")
-    -- Replace RichText tags since char-by-char animation will break the tags
+    -- Remove RichText tags since char-by-char animation will break the tags
    	displayText = displayText:gsub("<[^<>]->", "")
 
    	-- Set translated/modified text on parent

--- a/content/en-us/ui/animation.md
+++ b/content/en-us/ui/animation.md
@@ -543,7 +543,8 @@ The "typewriter" effect is ideal for `Class.TextLabel|TextLabels` that tell a st
 
    	-- Replace line break tags so grapheme loop will not miss those characters
    	displayText = displayText:gsub("<br%s*/>", "\n")
-   	displayText:gsub("<[^<>]->", "")
+    -- Replace RichText tags since char-by-char animation will break the tags
+   	displayText = displayText:gsub("<[^<>]->", "")
 
    	-- Set translated/modified text on parent
    	guiObject.Text = displayText


### PR DESCRIPTION
## Changes

Because strings are immutable, calling `gsub` without storing the result is not accomplishing anything. Additionally, there was no comment explaining what the `gsub` was doing. I fixed these issues, and also replaced `wait` with `task.wait` to adopt modern best practice.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
