### PR TITLE
Use correct syntax to access OnBubbleAdded

### DIFF
--- a/content/en-us/chat/bubble-chat.md
+++ b/content/en-us/chat/bubble-chat.md
@@ -285,7 +285,7 @@ The following tables include all available properties for customization:
 
 You can individually style and modify chat bubble behaviors based on specific conditions that overrides your general settings. For example, you can use chat bubbles to differentiate NPCs and users, highlight critical health status, and apply special effects to messages with pre-defined keywords.
 
-To set per-bubble customization, add a client-side `Class.LocalScript` using `Class.BubbleChatMessageProperties`, which overrides matching properties of `Class.BubbleChatConfiguration`, and the `Class.TextChatService:OnBubbleAdded()` callback to specify how to customize each bubble. The callback supplies you with the `Class.TextChatMessage` property as well as the adornee, so you can apply the customization based on attributes associated with users, the chat text content, user character properties, and any special conditions you want to define.
+To set per-bubble customization, add a client-side `Class.LocalScript` using `Class.BubbleChatMessageProperties`, which overrides matching properties of `Class.BubbleChatConfiguration`, and the `Class.TextChatService.OnBubbleAdded` callback to specify how to customize each bubble. The callback supplies you with the `Class.TextChatMessage` property as well as the adornee, so you can apply the customization based on attributes associated with users, the chat text content, user character properties, and any special conditions you want to define.
 
 The following example adds special appearance to VIP users' chat bubbles by checking if a chat message sender has the `IsVIP` attribute:
 
@@ -399,4 +399,4 @@ end
 
 ## NPC Bubbles
 
-You can display chat bubbles for non-player characters (NPCs) by calling `Class.TextChatService:DisplayBubble()`, with the NPC character and the message as parameters. These bubbles are customizable using the `Class.TextChatService:OnBubbleAdded()` callback just like any other chat bubble.
+You can display chat bubbles for non-player characters (NPCs) by calling `Class.TextChatService:DisplayBubble()`, with the NPC character and the message as parameters. These bubbles are customizable using the `Class.TextChatService.OnBubbleAdded` callback just like any other chat bubble.


### PR DESCRIPTION
## Changes

Quick wordsmithing for bubble chat docs; OnBubbleAdded is presented as a method in the text however it is properly a callback that can be set. This is correct in the code sample and API, so the wordsmithing brings the text to match.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
