### PR TITLE
fix: inconsistent link

### DIFF
--- a/content/en-us/tutorials/scripting/intermediate-scripting/creating-a-health-pickup.md
+++ b/content/en-us/tutorials/scripting/intermediate-scripting/creating-a-health-pickup.md
@@ -200,7 +200,7 @@ The pickup should provide visual feedback that it is disabled - a common way to 
    end
    ```
 
-3. Call the `Global.RobloxGlobals.wait()|task.wait` function, passing `COOLDOWN` as the amount to wait.
+3. Call the `Library.task.wait()` function, passing `COOLDOWN` as the amount to wait.
 4. Set `Transparency` back to `ENABLED_TRANSPARENCY` and `Enabled` back to `true`.
 
    ```lua


### PR DESCRIPTION
## Changes

Fix inconsistent link inside `tutorials/scripting/intermediate-scripting/creating-a-health-pickup.md`

In the `Disabling the pickup` section, task.wait() was incorrectly links to the deprecated wait global function

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
