### PR TITLE
Replaced ModifierID with Label property

### DIFF
--- a/content/en-us/characters/pathfinding.md
+++ b/content/en-us/characters/pathfinding.md
@@ -543,8 +543,8 @@ To create a `Class.PathfindingLink` using this example:
    					-- Increase waypoint index and move to next waypoint
    					nextWaypointIndex += 1
 
-   					-- Use boat if waypoint modifier ID is "UseBoat"; otherwise move to next waypoint
-   					if waypoints[nextWaypointIndex].ModifierId == "UseBoat" then
+   					-- Use boat if waypoint label is the modifier ID "UseBoat"; otherwise move to next waypoint
+   					if waypoints[nextWaypointIndex].Label == "UseBoat" then
    						useBoat()
    					else
    						humanoid:MoveTo(waypoints[nextWaypointIndex].Position)

--- a/content/en-us/characters/pathfinding.md
+++ b/content/en-us/characters/pathfinding.md
@@ -543,7 +543,7 @@ To create a `Class.PathfindingLink` using this example:
    					-- Increase waypoint index and move to next waypoint
    					nextWaypointIndex += 1
 
-   					-- Use boat if waypoint label is the modifier ID "UseBoat"; otherwise move to next waypoint
+   					-- Use boat if waypoint label is "UseBoat"; otherwise move to next waypoint
    					if waypoints[nextWaypointIndex].Label == "UseBoat" then
    						useBoat()
    					else


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

The code segment used to try to use the ModifierID property of a PathWaypoint. This property does not exist. I replaced it with the Label property. This is the correct property to find the ModifierID of a PathWaypoint.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

You can view my forum post from May talking about this issue here: https://devforum.roblox.com/t/incorrect-pathfinding-modifier-documentationcant-post-there/2317981.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
