### PR TITLE
Update SetAsync example to correctly use player data

### DIFF
--- a/content/en-us/players/index.md
+++ b/content/en-us/players/index.md
@@ -67,8 +67,9 @@ game:GetService("Players").PlayerRemoving:Connect(function(player)
 
 	-- Save to data store
 	local setSuccess, errorMessage = pcall(function()
-	    playerDataStore:SetAsync(userId, playerDataStore)
+	    playerDataStore:SetAsync(userId, currentData)
 	end)
+
 	if not setSuccess then
 	    warn(errorMessage)
 	end


### PR DESCRIPTION
## Changes

The current example tries to save the Data Store object instead of the player's data. This replaces the 2nd argument of the call to use the player's current data instead of the Data Store object.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
