### PR TITLE
refactor: use `ipairs` for array instead of `pairs`

### DIFF
--- a/content/en-us/animation/using.md
+++ b/content/en-us/animation/using.md
@@ -106,7 +106,7 @@ climbing, swimming, and jumping. You can replace these [default animations](#def
    	local animator = humanoid:WaitForChild("Animator")
 
    	-- Stop all animation tracks
-   	for _, playingTrack in pairs(animator:GetPlayingAnimationTracks()) do
+   	for _, playingTrack in ipairs(animator:GetPlayingAnimationTracks()) do
    		playingTrack:Stop(0)
    	end
 
@@ -140,7 +140,7 @@ climbing, swimming, and jumping. You can replace these [default animations](#def
    	local animator = humanoid:WaitForChild("Animator")
 
    	-- Stop all animation tracks
-   	for _, playingTrack in pairs(animator:GetPlayingAnimationTracks()) do
+   	for _, playingTrack in ipairs(animator:GetPlayingAnimationTracks()) do
    		playingTrack:Stop(0)
    	end
 

--- a/content/en-us/characters/appearance.md
+++ b/content/en-us/characters/appearance.md
@@ -250,7 +250,7 @@ end
 Use the following sample code to apply a `Class.HumanoidDescription` to all current players in the game:
 
 ```lua
-for \_, player in pairs(game.Players:GetPlayers()) do
+for _, player in ipairs(game.Players:GetPlayers()) do
   local humanoid = player.Character and player.Character:FindFirstChild("Humanoid")
   if humanoid then
     -- Create a HumanoidDescription

--- a/content/en-us/cloud-services/datastores.md
+++ b/content/en-us/cloud-services/datastores.md
@@ -294,7 +294,7 @@ if success then
 		-- Get the current (first) page
 		local entries = pages:GetCurrentPage()
 		-- Iterate through all key-value pairs on page
-		for _, entry in pairs(data) do
+		for _, entry in ipairs(data) do
 			print(entry.key .. " : " .. tostring(entry.value))
 		end
 		-- Check if last page has been reached

--- a/content/en-us/education/battle-royale-series/cleanup-and-reset.md
+++ b/content/en-us/education/battle-royale-series/cleanup-and-reset.md
@@ -244,11 +244,11 @@ When players move into the transition state, remove their weapons.
    return PlayerManager
    ```
 
-3. In that function, use a for loop with `pairs()` to go through the active players table. In the loop, call `removePlayerWeapon()` and pass in the player found.
+3. In that function, use a for loop with `ipairs()` to go through the active players table. In the loop, call `removePlayerWeapon()` and pass in the player found.
 
    ```lua
    function PlayerManager.removeAllWeapons()
-     for playerKey, whichPlayer in pairs(activePlayers) do
+     for playerKey, whichPlayer in ipairs(activePlayers) do
        removePlayerWeapon(whichPlayer)
      end
    end
@@ -318,12 +318,12 @@ First, start a function to send players back to the lobby.
 1. In PlayerManager:
 
    - Create a module function named `resetPlayers()`.
-   - Add a for loop with `pairs()` to iterate through activePlayers.
+   - Add a for loop with `ipairs()` to iterate through activePlayers.
    - In the loop, call `respawnPlayerInLobby()` and pass in the player as the parameter.
 
    ```lua
    function PlayerManager.resetPlayers()
-     for playerKey, whichPlayer in pairs(activePlayers) do
+     for playerKey, whichPlayer in ipairs(activePlayers) do
        respawnPlayerInLobby(whichPlayer)
      end
    end
@@ -559,7 +559,7 @@ end
 
 local function removeActivePlayer(player)
 	print("removing player")
-	for playerKey, whichPlayer in pairs(activePlayers) do
+	for playerKey, whichPlayer in ipairs(activePlayers) do
 		if whichPlayer == player then
 			table.remove(activePlayers, playerKey)
 			playersLeft.Value = #activePlayers
@@ -616,7 +616,7 @@ end
 function PlayerManager.sendPlayersToMatch()
 	local availableSpawnPoints = spawnLocations:GetChildren()
 
-	for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
+	for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
 		table.insert(activePlayers,whichPlayer)
 
 		-- Gets a spawn location and then removes it from the table so the next player gets the next spawn
@@ -638,13 +638,13 @@ function PlayerManager.getWinnerName()
 end
 
 function PlayerManager.removeAllWeapons()
-	for playerKey, whichPlayer in pairs(activePlayers) do
+	for playerKey, whichPlayer in ipairs(activePlayers) do
 		removePlayerWeapon(whichPlayer)
 	end
 end
 
 function PlayerManager.resetPlayers()
-	for playerKey, whichPlayer in pairs(activePlayers) do
+	for playerKey, whichPlayer in ipairs(activePlayers) do
 		respawnPlayerInLobby(whichPlayer)
 	end
 

--- a/content/en-us/education/battle-royale-series/creating-a-gui.md
+++ b/content/en-us/education/battle-royale-series/creating-a-gui.md
@@ -319,7 +319,7 @@ Next, add the code for displaying the number of players at the start of a game. 
    function PlayerManager.sendPlayersToMatch()
       local availableSpawnPoints = spawnLocations:GetChildren()
 
-      for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
+      for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
          table.insert(activePlayers,whichPlayer)
 
          local spawnLocation = availableSpawnPoints[1]

--- a/content/en-us/education/battle-royale-series/ending-matches.md
+++ b/content/en-us/education/battle-royale-series/ending-matches.md
@@ -270,11 +270,11 @@ An accurate count can't be kept unless players are removed. When a player is def
    end
    ```
 
-2. To find the player in the activePlayers table, use a for loop with `pairs()` that goes through the `activePlayer` table. Then, add an if statement that runs if a player matching the name passed into the function is found.
+2. To find the player in the activePlayers table, use a for loop with `ipairs()` that goes through the `activePlayer` table. Then, add an if statement that runs if a player matching the name passed into the function is found.
 
    ```lua
    local function removeActivePlayer(player)
-     for playerKey, whichPlayer in pairs(activePlayers) do
+     for playerKey, whichPlayer in ipairs(activePlayers) do
        if whichPlayer == player then
 
        end
@@ -296,7 +296,7 @@ An accurate count can't be kept unless players are removed. When a player is def
 
    ```lua
    local function removeActivePlayer(player)
-     for playerKey, whichPlayer in pairs(activePlayers) do
+     for playerKey, whichPlayer in ipairs(activePlayers) do
        if whichPlayer == player then
          table.remove(activePlayers, playerKey)
          playersLeft.Value = #activePlayers
@@ -413,7 +413,7 @@ local function checkPlayerCount()
 end
 
 local function removeActivePlayer(player)
-	for playerKey, whichPlayer in pairs(activePlayers) do
+	for playerKey, whichPlayer in ipairs(activePlayers) do
 		if whichPlayer == player then
 			table.remove(activePlayers, playerKey)
 			playersLeft.Value = #activePlayers
@@ -453,7 +453,7 @@ end
 function PlayerManager.sendPlayersToMatch()
 	local arenaSpawns = spawnLocations:GetChildren()
 
-	for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
+	for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
 		table.insert(activePlayers,whichPlayer)
 		local spawnLocation = arenaSpawns[1]
 		preparePlayer(whichPlayer, spawnLocation)

--- a/content/en-us/education/battle-royale-series/managing-players.md
+++ b/content/en-us/education/battle-royale-series/managing-players.md
@@ -188,7 +188,7 @@ Now that players spawn in the lobby, teleport them into a match once the intermi
 
 ### Sending Players to Spawn
 
-Make sure each player gets teleported to a different spawn location in the arena by combining a for loop and the `pairs()` function to go through the active players array. Using `pairs()` allows you to go through every value in the players array, allowing the script to adapt to a variety of player numbers.
+Make sure each player gets teleported to a different spawn location in the arena by combining a for loop and the `ipairs()` function to go through the active players array. Using `ipairs()` allows you to go through every value in the players array, allowing the script to adapt to a variety of player numbers.
 
 1. In the `sendPlayersToMatch()` function, use a variable to create an array of all the arena spawn locations by getting the children of the Arena > SpawnLocations folder.
 
@@ -199,13 +199,13 @@ Make sure each player gets teleported to a different spawn location in the arena
    end
    ```
 
-2. Add the for loop below to get an array of all players and then iterate through each of them. To get players, type: `pairs(Players:GetPlayers())`.
+2. Add the for loop below to get an array of all players and then iterate through each of them. To get players, type: `ipairs(Players:GetPlayers())`.
 
    ```lua
    function PlayerManager.sendPlayersToMatch()
       local arenaSpawns = spawnLocations:GetChildren()
 
-      for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
+      for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
 
       end
    end
@@ -221,8 +221,8 @@ When the game runs, it needs to identify which users are playing so they can be 
    function PlayerManager.sendPlayersToMatch()
       local arenaSpawns = spawnLocations:GetChildren()
 
-      for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
-         table.insert(activePlayers,whichPlayer)
+      for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
+         table.insert(activePlayers, whichPlayer)
       end
    end
    ```
@@ -230,8 +230,8 @@ When the game runs, it needs to identify which users are playing so they can be 
 2. To get a spawn location from the arena, create a variable named `spawnLocation` and set it to the **first** index in the `arenaSpawns` table.
 
    ```lua
-   for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
-      table.insert(activePlayers,whichPlayer)
+   for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
+      table.insert(activePlayers, whichPlayer)
       local spawnLocation = arenaSpawns[1]
    end
    ```
@@ -239,7 +239,7 @@ When the game runs, it needs to identify which users are playing so they can be 
 3. Call `preparePlayer()` and pass in `whichPlayer` and `spawnLocation`. Then, since that spawn location was used, **remove** it from the table so the next player will get a different spawn.
 
    ```lua
-   for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
+   for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
       table.insert(activePlayers,whichPlayer)
       local spawnLocation = arenaSpawns[1]
       preparePlayer(whichPlayer, spawnLocation)
@@ -410,8 +410,8 @@ function PlayerManager.sendPlayersToMatch()
 
 local arenaSpawns = spawnLocations:GetChildren()
 
-	for playerKey, whichPlayer in pairs(Players:GetPlayers()) do
-		table.insert(activePlayers,whichPlayer)
+	for playerKey, whichPlayer in ipairs(Players:GetPlayers()) do
+		table.insert(activePlayers, whichPlayer)
 		local spawnLocation = arenaSpawns[1]
 		preparePlayer(whichPlayer, spawnLocation)
 		table.remove(arenaSpawns, 1)

--- a/content/en-us/input/gamepad.md
+++ b/content/en-us/input/gamepad.md
@@ -69,7 +69,7 @@ local UserInputService = game:GetService("UserInputService")
 
 local availableInputs = UserInputService:GetSupportedGamepadKeyCodes(Enum.UserInputType.Gamepad2)
 print("This controller supports the following controls:")
-for _, control in pairs(availableInputs) do
+for _, control in ipairs(availableInputs) do
 	print(control)
 end
 ```
@@ -144,7 +144,7 @@ local leftFoot = character:WaitForChild("LeftFoot")
 -- When leftFoot comes into contact with something, check the gamepad input state
 leftFoot.Touched:Connect(function(hit)
 	local state = UserInputService:GetGamepadState(Enum.UserInputType.Gamepad1)
-	for _, input in pairs(state) do
+	for _, input in ipairs(state) do
 
 		-- If the ButtonR2 is currently held then print out a message
 		if input.KeyCode == Enum.KeyCode.ButtonR2 and input.UserInputState == Enum.UserInputState.Begin then

--- a/content/en-us/production/monetization/developer-products.md
+++ b/content/en-us/production/monetization/developer-products.md
@@ -188,7 +188,7 @@ local success, developerProducts = pcall(function()
 end)
 
 if developerProducts then
-	for _, developerProduct in pairs(developerProducts) do
+	for _, developerProduct in ipairs(developerProducts) do
 		for field, value in pairs(developerProduct) do
 			print(field .. ": " .. value)
 		end

--- a/content/en-us/production/publishing/account-verification.md
+++ b/content/en-us/production/publishing/account-verification.md
@@ -73,7 +73,7 @@ The following script checks the verification status of each player as they join 
   local function onPlayerAdded(player)
     print(player:IsVerified())
   end
-  for _, player in pairs(Players:GetPlayers()) do
+  for _, player in ipairs(Players:GetPlayers()) do
     onPlayerAdded(player)
   end
   Players.PlayerAdded:Connect(onPlayerAdded)

--- a/content/en-us/resources/beyond-the-dark/custom-characters.md
+++ b/content/en-us/resources/beyond-the-dark/custom-characters.md
@@ -178,12 +178,12 @@ The skinned character's mesh positions aren't updated when the Creature animates
    local vfxTable = {} -- where we will store all the parts and offsets
 
    -- Assign a table to each model that will hold all vfx parts and offset
-   for _, model in pairs(vfxModels) do
+   for _, model in ipairs(vfxModels) do
     vfxTable[model] = {}
     local vfxParts = model:FindFirstChild("VFX"):GetChildren() -- Find theVFX folder
 
     -- Find the bone via attribute and calculate the offset for each part.
-    for _,part in pairs(vfxParts) do
+    for _,part in ipairs(vfxParts) do
       local name = part:GetAttribute("AttachedBoneName")
       local bone = model:FindFirstChild(name, true)
       if (bone) then

--- a/content/en-us/resources/modules/photo-booth.md
+++ b/content/en-us/resources/modules/photo-booth.md
@@ -132,7 +132,7 @@ specialLabel.Parent = specialGuiInstance
 PhotoBooth.hideOtherGuis(function()
 	-- Hide all developer-defined screen GUIs except those marked with attribute
 	local instances = playerGui:GetChildren()
-	for _, instance in pairs(instances) do
+	for _, instance in ipairs(instances) do
 		if instance:IsA("ScreenGui") and not instance:GetAttribute("ShowInPhotoBooth") and instance.Enabled then
 			instance.Enabled = false
 			table.insert(hiddenInstances, instance)
@@ -144,7 +144,7 @@ end)
 
 PhotoBooth.showOtherGuis(function()
 	-- Show all developer-defined screen GUIs that were hidden
-	for _, instance in pairs(hiddenInstances) do
+	for _, instance in ipairs(hiddenInstances) do
 		instance.Enabled = true
 	end
 	hiddenInstances = {}

--- a/content/en-us/resources/modules/scavenger-hunt.md
+++ b/content/en-us/resources/modules/scavenger-hunt.md
@@ -193,7 +193,7 @@ specialLabel.Parent = specialGuiInstance
 ScavengerHunt.hideOtherGuis(function()
 	-- Hide all developer-defined screen GUIs
 	local instances = playerGui:GetChildren()
-	for _, instance in pairs(instances) do
+	for _, instance in ipairs(instances) do
 		if instance:IsA("ScreenGui") and not instance.Name == "ScavengerHunt" and instance.Enabled then
 			instance.Enabled = false
 			table.insert(hiddenInstances, instance)
@@ -205,7 +205,7 @@ end)
 
 ScavengerHunt.showOtherGuis(function()
 	-- Show all developer-defined screen GUIs that were hidden
-	for _, instance in pairs(hiddenInstances) do
+	for _, instance in ipairs(hiddenInstances) do
 		instance.Enabled = true
 	end
 	hiddenInstances = {}

--- a/content/en-us/resources/the-mystery-of-duvall-drive/developing-a-moving-world.md
+++ b/content/en-us/resources/the-mystery-of-duvall-drive/developing-a-moving-world.md
@@ -73,7 +73,7 @@ In our demo, portions of the world are cloned from the `Class.ServerStorage` int
 
 ```lua
 local function Init()
-	for _,obj in pairs(CollectionService:GetTagged("LocalSpaceRotation")) do
+	for _,obj in ipairs(CollectionService:GetTagged("LocalSpaceRotation")) do
 		if(obj:IsDescendantOf(workspace)) then
 			SetupObj(obj)
 		end
@@ -537,7 +537,7 @@ To do this, we needed to first use assets from our current kit and add any new c
 
 <img src="../../assets/resources/mystery-of-duvall-drive/developing-a-moving-world/base-piece.png" width="100%" />
 
-We knew that since we were using constraints, we wouldn't be able to anchor these meshes because they wouldn't move even with the presence of a constraint/motor driving them. The constraint needed to be a child of something that was anchored in order for the platform to not just fall out of the world. We solved this through an part we named **Motor_Anchor** that had a [hinge constraint](../../physics/mechanical-constraints.md#hingeconstraint) to drive the overall movement of the platform. After that, we needed the two meshes to move as one, so we created a part we named **Motor_Turn**, then we welded the two meshes to it. This way the constraint would be able to work on a single part, as opposed to multiple hinges working with multiple parts.
+We knew that since we were using constraints, we wouldn't be able to anchor these meshes because they wouldn't move even with the presence of a constraint/motor driving them. The constraint needed to be a child of something that was anchored in order for the platform to not just fall out of the world. We solved this through a part we named **Motor_Anchor** that had a [hinge constraint](../../physics/mechanical-constraints.md#hingeconstraint) to drive the overall movement of the platform. After that, we needed the two meshes to move as one, so we created a part we named **Motor_Turn**, then we welded the two meshes to it. This way the constraint would be able to work on a single part, as opposed to multiple hinges working with multiple parts.
 
 <img src="../../assets/resources/mystery-of-duvall-drive/developing-a-moving-world/unanchored-platform.png" width="100%" />
 

--- a/content/en-us/studio/building-studio-widgets.md
+++ b/content/en-us/studio/building-studio-widgets.md
@@ -127,7 +127,7 @@ testButton.Parent = testWidget
 
 local function syncGuiColors(objects)
 	local function setColors()
-		for _, guiObject in pairs(objects) do
+		for _, guiObject in ipairs(objects) do
 			-- Sync background color
 			guiObject.BackgroundColor3 = settings().Studio.Theme:GetColor(Enum.StudioStyleGuideColor.MainBackground)
 			-- Sync text color

--- a/content/en-us/studio/plugins.md
+++ b/content/en-us/studio/plugins.md
@@ -83,7 +83,7 @@ local button = toolbar:CreateButton("Neon it up", "", "")
 -- Connect a function to the click event
 button.Click:Connect(function()
     local parts = {}
-    for _, part in pairs(Selection:Get()) do
+    for _, part in ipairs(Selection:Get()) do
         if part:IsA("BasePart") then
             parts[#parts + 1] = part
         end
@@ -105,7 +105,7 @@ button.Click:Connect(function()
     end
 
     -- Iterate through the selected parts
-    for _, part in pairs(parts) do
+    for _, part in ipairs(parts) do
         part.Material = Enum.Material.Neon -- Set the material of the part to Neon
     end
 

--- a/content/en-us/workspace/collisions.md
+++ b/content/en-us/workspace/collisions.md
@@ -97,7 +97,7 @@ local function onTouchEnded(otherPart)
 	print(model.Name, "un-intersected from", otherPart.Name, "| Model parts touching:", numTouchingParts)
 end
 
-for _, child in pairs(model:GetChildren()) do
+for _, child in ipairs(model:GetChildren()) do
 	if child:IsA("BasePart") then
 		child.Touched:Connect(onTouched)
 		child.TouchEnded:Connect(onTouchEnded)
@@ -309,7 +309,7 @@ end
 
 local function onCharacterAdded(character)
 	-- Process existing and new descendants for physics setup
-	for _, descendant in pairs(character:GetDescendants()) do
+	for _, descendant in ipairs(character:GetDescendants()) do
 		onDescendantAdded(descendant)
 	end
 	character.DescendantAdded:Connect(onDescendantAdded)


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

Replace all instance of `pairs` that was used with an array with `ipairs` as `ipairs` is much faster than `pairs` when used with an array

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
