### PR TITLE
Correct the maximum ray magnitude text

### DIFF
--- a/content/en-us/workspace/raycasting.md
+++ b/content/en-us/workspace/raycasting.md
@@ -22,7 +22,7 @@ local raycastResult = workspace:Raycast(rayOrigin, rayDirection)
 ```
 
 <Alert severity="warning">
-When casting a ray, the distance between the origin and directional `Datatype.Vector3` is the **functional length** (magnitude) of the ray. The maximum length is 5,000 studs.
+When casting a ray, the distance between the origin and directional `Datatype.Vector3` is the **functional length** (magnitude) of the ray. The maximum length is 15,000 studs.
 </Alert>
 
 ### Filtering


### PR DESCRIPTION
## Changes

Corrects the maximum ray magnitude text from 5,000 to 15,000.

Source: https://devforum.roblox.com/t/upgraded-improved-and-faster-raycasts/1420368 and RaycastMaxDistance DFFlag value

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
