### PR TITLE
Add auto-links to memory-stores

### DIFF
--- a/content/en-us/cloud-services/memory-stores/queue.md
+++ b/content/en-us/cloud-services/memory-stores/queue.md
@@ -45,7 +45,7 @@ After you get a queue, call any of the following functions to read or write data
 </table>
 
 <Alert severity="warning">
-All functions accessing data structures in memory stores are asynchronous network calls that might occasionally fail. You should wrap these calls in `pcall()` to catch and handle errors, like the code sample in each section shows.
+All functions accessing data structures in memory stores are asynchronous network calls that might occasionally fail. You should wrap these calls in `Global.LuaGlobals.pcall()` to catch and handle errors, like the code sample in each section shows.
 </Alert>
 
 ## Adding Data

--- a/content/en-us/cloud-services/memory-stores/sorted-map.md
+++ b/content/en-us/cloud-services/memory-stores/sorted-map.md
@@ -55,7 +55,7 @@ After you get a sorted map, call any of the following functions to read or write
 </table>
 
 <Alert severity="warning">
-All functions accessing data structures in memory stores are asynchronous network calls that might occasionally fail. You should wrap these calls in `pcall()` to catch and handle errors, like the code sample in each section does.
+All functions accessing data structures in memory stores are asynchronous network calls that might occasionally fail. You should wrap these calls in `Global.LuaGlobals.pcall()` to catch and handle errors, like the code sample in each section does.
 </Alert>
 
 ## Adding or Overwriting Data


### PR DESCRIPTION
## Changes

Added auto-links to pcall. observability.md might also have a missing auto-link but I did not modify it in case it was intentional.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
