### PR TITLE
Add Font datatype to attributes supported list

### DIFF
--- a/content/en-us/studio/instance-attributes.md
+++ b/content/en-us/studio/instance-attributes.md
@@ -59,6 +59,7 @@ You can store the following types/values in attributes:
 			<li>`Datatype.ColorSequence`</li>
 			<li>`Datatype.NumberRange`</li>
 			<li>`Datatype.Rect`</li>
+			<li>`Datatype.Font`</li>
 		</ul>
 	</Grid>
 </Grid>


### PR DESCRIPTION
Super quick addition of Font as a supported type for instance attributes.