### PR TITLE
Remove unused variables

### DIFF
--- a/content/en-us/production/localization/localizing-with-scripting.md
+++ b/content/en-us/production/localization/localizing-with-scripting.md
@@ -391,8 +391,6 @@ function TranslationHelper.translate(text, object)
 	if not object then
 		object = game
 	end
-	local translation = ""
-	local foundTranslation = false
 	if foundPlayerTranslator then
 		return playerTranslator:Translate(object, text)
 	end


### PR DESCRIPTION
## Changes
Removes two unused variables from the [Localizing with Scripting](https://create.roblox.com/docs/production/localization/localizing-with-scripting#creating-a-translationhelper-module) page. These appear to be left over from another function, and now only serve to confuse the reader. 

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
