### PR TITLE
Improve code in using-particles-for-explosions.md

### DIFF
--- a/content/en-us/tutorials/building/effects/using-particles-for-explosions.md
+++ b/content/en-us/tutorials/building/effects/using-particles-for-explosions.md
@@ -112,7 +112,7 @@ With the emitter complete, the explosion can now be played through a script. The
 
    ```lua
    local trapObject = script.Parent
-   local particleEmitter = trapObject:FindFirstChild("Explosion")
+   local particleEmitter = trapObject.Explosion
 
    local EMIT_AMOUNT = 100
    ```
@@ -121,9 +121,9 @@ With the emitter complete, the explosion can now be played through a script. The
 
    ```lua
    local trapObject = script.Parent
-   local particleEmitter = trapObject:FindFirstChild("Explosion")
+   local particleEmitter = trapObject.Explosion
 
-   local EMIT_AMOUNT= 30
+   local EMIT_AMOUNT = 100
 
    local function killPlayer(otherPart)
        local character = otherPart.Parent
@@ -145,9 +145,9 @@ In scripts, particles are emitted using the `Class.ParticleEmitter:Emit()|Emit()
 
    ```lua
    local trapObject = script.Parent
-   local particleEmitter = trapObject:FindFirstChild("Explosion")
+   local particleEmitter = trapObject.Explosion
 
-   local EMIT_AMOUNT= 100
+   local EMIT_AMOUNT = 100
 
    local function killPlayer(otherPart)
        local character = otherPart.Parent


### PR DESCRIPTION
## Changes

Removed unnecessary `:FindFirstChild()`s. Replaced 30 with 100 because that was the value for both other code snippets.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
