### PR TITLE
Improve formatting in creating-a-health-pickup.md

### DIFF
--- a/content/en-us/tutorials/scripting/intermediate-scripting/creating-a-health-pickup.md
+++ b/content/en-us/tutorials/scripting/intermediate-scripting/creating-a-health-pickup.md
@@ -78,7 +78,7 @@ When called on a folder, the `GetChildren` function will return an array of the 
    local healthPickups = healthPickupsFolder:GetChildren()
 
    local function onTouchHealthPickup(otherPart, healthPickup)
-   local character = otherPart.Parent
+      local character = otherPart.Parent
    	local humanoid = character:FindFirstChildWhichIsA("Humanoid")
    	if humanoid then
    		humanoid.Health = MAX_HEALTH


### PR DESCRIPTION
## Changes

Added a missing indent.

Note: There are several code improvements that can be made on this page, but I am not too good at writing so I'll explain them here so a better writer than me can handle it.

`ipairs` is not needed in this loop (as generalized iteration was added), and it's performance is worse than the method I mentioned earlier. An example of "ideal" code would be:
```
for _, healthPickup in healthPickups do

end
```

This script does not detect when new health pickups are added (which would be fairly common to do), which can be easily fixed by adding a .ChildAdded statement.

Code:

```
healthPickupsFolder.ChildAdded:Connect(function(healthPickup)
	healthPickup:SetAttribute("Enabled", true)
	healthPickup.Touched:Connect(function(otherPart)
		onTouchHealthPickup(otherPart, healthPickup)
	end)
end)
```

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
