### PR TITLE
Fix auto-link in drag-detectors.md

### DIFF
--- a/content/en-us/ui/drag-detectors.md
+++ b/content/en-us/ui/drag-detectors.md
@@ -291,7 +291,7 @@ end)
 
 ### Scripted DragStyle
 
-If you set a detector's `Class.DragDetector.DragStyle|DragStyle` to **Scriptable**, you can provide your own function that takes in a `Class.Ray` and returns a world space `Datatype.CFrame`. The detector will move the motion so that the dragged object goes to that custom location/orientation.
+If you set a detector's `Class.DragDetector.DragStyle|DragStyle` to **Scriptable**, you can provide your own function that takes in a `Datatype.Ray` and returns a world space `Datatype.CFrame`. The detector will move the motion so that the dragged object goes to that custom location/orientation.
 
 ```lua title='DragDetector - Scripted DragStyle' highlight='2,7,31,32,34'
 local dragDetector = script.Parent.DragDetector


### PR DESCRIPTION
## Changes

Replaced `Class.Ray` with `Datatype.Ray` as `Class.Ray` does not exist.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
