### PR TITLE
Remove reference to FilteringEnabled in `TouchTransmitter.yml`

### DIFF
--- a/content/en-us/reference/engine/classes/TouchTransmitter.yaml
+++ b/content/en-us/reference/engine/classes/TouchTransmitter.yaml
@@ -14,8 +14,7 @@ description: |
   `Class.BasePart.TouchEnded` events are listened (connected) to.
 
   Removing the TouchTransmitter will prevent the touched events from working.
-  The TouchTransmitter object can also be removed exclusively on the client
-  (when `Class.Workspace.FilteringEnabled` is set to true). This will prevent
+  The TouchTransmitter object can also be removed exclusively on the client. This will prevent
   collisions from models the client has network ownership of (such as the
   player's character) from registering.
 


### PR DESCRIPTION
## Changes

[FilteringEnabled no longer exists](https://devforum.roblox.com/t/removal-of-experimental-mode/152807) so this doesn't make sense anymore.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
