### PR TITLE
Fix auto-links in AnimationTrack.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/AnimationTrack.yaml
+++ b/content/en-us/reference/engine/classes/AnimationTrack.yaml
@@ -56,7 +56,7 @@ properties:
 
       This property can be used by developers to check if an animation is
       already playing before playing it (as that would cause it to restart). If
-      a developer wishes to obtain all playing `Class.AnimationTrack`s on a
+      a developer wishes to obtain all playing `Class.AnimationTrack|AnimationTracks` on a
       `Class.Humanoid` or `Class.AnimationController` they should use
       `Class.Humanoid:GetPlayingAnimationTracks()`
     code_samples:
@@ -139,12 +139,12 @@ properties:
     summary: |
       Sets the priority of an `Class.AnimationTrack`. Depending on what this is
       set to, playing multiple animations at once will look to this property to
-      figure out which `Class.Keyframe` `Class.Pose`s should be played over one
+      figure out which `Class.Keyframe` `Class.Pose|Poses` should be played over one
       another.
     description: |
       This property sets the priority of an `Class.AnimationTrack`. Depending on
       what this is set to, playing multiple animations at once will look to this
-      property to figure out which `Class.Keyframe` `Class.Pose`s should be
+      property to figure out which `Class.Keyframe` `Class.Pose|Poses` should be
       played over one another.
 
       The Priority property for `Class.AnimationTrack` defaults to how it was
@@ -268,11 +268,11 @@ properties:
       sufficiently small (see code sample below).
 
       The animation weighting system is used to determine how
-      `Class.AnimationTrack`s playing at the same priority are blended together.
+      `Class.AnimationTrack|AnimationTracks` playing at the same priority are blended together.
       The default weight is one, and no movement will be visible on an
       `Class.AnimationTrack` with a weight of zero. The pose that is shown at
       any point in time is determined by the weighted average of all the
-      `Class.Pose`s and the WeightCurrent of each `Class.AnimationTrack`. In
+      `Class.Pose|Poses` and the WeightCurrent of each `Class.AnimationTrack`. In
       most cases blending animations is not required and using
       `Class.AnimationTrack.Priority` is more suitable.
     code_samples:
@@ -312,11 +312,11 @@ properties:
       sufficiently small (see code sample below).
 
       The animation weighting system is used to determine how
-      `Class.AnimationTrack`s playing at the same priority are blended together.
+      `Class.AnimationTrack|AnimationTracks` playing at the same priority are blended together.
       The default weight is one, and no movement will be visible on an
       `Class.AnimationTrack` with a weight of zero. The pose that is shown at
       any point in time is determined by the weighted average of all the
-      `Class.Pose`s and the WeightCurrent of each `Class.AnimationTrack`. In
+      `Class.Pose|Poses` and the WeightCurrent of each `Class.AnimationTrack`. In
       most cases blending animations is not required and using
       `Class.AnimationTrack.Priority` is more suitable.
     code_samples:
@@ -399,11 +399,11 @@ methods:
       sufficiently small (see code sample below).
 
       The animation weighting system is used to determine how
-      `Class.AnimationTrack`s playing at the same priority are blended together.
+      `Class.AnimationTrack|AnimationTracks` playing at the same priority are blended together.
       The default weight is one, and no movement will be visible on an
       `Class.AnimationTrack` with a weight of zero. The pose that is shown at
       any point in time is determined by the weighted average of all the
-      `Class.Pose`s and the WeightCurrent of each `Class.AnimationTrack`. See
+      `Class.Pose|Poses` and the WeightCurrent of each `Class.AnimationTrack`. See
       below for an example of animation blending in practice. In most cases
       blending animations is not required and using
       `Class.AnimationTrack.Priority` is more suitable.
@@ -487,7 +487,7 @@ methods:
       in an `Class.AnimationTrack`.
     description: |
       Returns the time position of the first `Class.Keyframe` of the given name
-      in an `Class.AnimationTrack`. If multiple `Class.Keyframe`s share the same
+      in an `Class.AnimationTrack`. If multiple `Class.Keyframe|Keyframes` share the same
       name, it will return the earliest one in the animation.
 
       This function will return an error if it is uses with an invalid keyframe
@@ -654,7 +654,7 @@ events:
       This event allows a developer to run code at predefined points in an
       animation (set by `Class.Keyframe` names). This allows the default
       functionality of Roblox animations to be expanded upon by adding
-      `Class.Sound`s or `ParticleEffect`s at different points in an animation.
+      `Class.Sound|Sounds` or `ParticleEffects` at different points in an animation.
 
       `Class.Keyframe` names do not need to be unique. For example, if an
       Animation has three keyframes named "Particles" the KeyframeReached event
@@ -692,7 +692,7 @@ events:
       This event has a number of uses. It can be used to wait until an
       `Class.AnimationTrack` has stopped before continuing (for example, if
       chaining a series of animations to play after each other). It can also be
-      used to clean up any `Class.Instance`s created during the animation
+      used to clean up any `Class.Instance|Instances` created during the animation
       playback.
     code_samples:
       - AnimationTrack-Stopped


### PR DESCRIPTION
## Changes

Improved text overrides for auto-links by including "s".

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
