### PR TITLE
Fix description in AvatarEditorService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/AvatarEditorService.yaml
+++ b/content/en-us/reference/engine/classes/AvatarEditorService.yaml
@@ -135,7 +135,7 @@ methods:
     summary: |
       Prompts the `Class.Players.LocalPlayer` to rename the given outfit.
     description: |
-      Prompts the `Class.Players.LocalPlayer` to delete the given outfit. Does
+      Prompts the `Class.Players.LocalPlayer` to rename the given outfit. Does
       not yield. The result can be retrieved by listening to the
       `Class.AvatarEditorService.PromptRenameOutfitCompleted` event.
     code_samples:


### PR DESCRIPTION
## Changes

Replaced "delete" with "rename" because `:PromptRenameOutfit` renames their outfit, while `:PromptDeleteOutfit` deletes their outfit.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
