### PR TITLE
Update UIAspectRatioConstraint.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/UIAspectRatioConstraint.yaml
+++ b/content/en-us/reference/engine/classes/UIAspectRatioConstraint.yaml
@@ -17,7 +17,7 @@ description: |
   `Class.UIAspectRatioConstraint.AspectRatio`. The
   `Class.UIAspectRatioConstraint.AspectType` sets what determines the maximum
   size of the object. When set to
-  `Class.UIAspectRatioConstraint.FitWithinMaxSize`, the constraint will make the
+  `Enum.AspectType.FitWithinMaxSize`, the constraint will make the
   object the maximum size it can be within the `Class.GuiObject` of the element.
   When set to ScaleWithParentSize, the elements maximum size will be the size of
   the parent while still maintaining the aspect ratio. Finally, the


### PR DESCRIPTION
UIAspectRatioConstraint.AspectType should be set to Enum.AspectType.FitWithinMaxSize not UIAspectRatioConstraint.FitWithinMaxSize

## Changes

Tiny fox to point to correct enum value instead of incorrect class member. Verified in code that this works.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
