### PR TITLE
PromptProductPurchaseFinished is no longer deprecated

### DIFF
--- a/content/en-us/reference/engine/classes/MarketplaceService.yaml
+++ b/content/en-us/reference/engine/classes/MarketplaceService.yaml
@@ -926,9 +926,6 @@ events:
       Unlike the similarly-named events above, this event fires with a
       `Class.Player.UserId` and not a reference to the `Class.Player` object.
 
-      Despite this event's deprecation, it is currently the only way to detect
-      when a developer product's purchase dialog is closed.
-
       - For [passes](../../../production/monetization/game-passes.md), use
         `Class.MarketplaceService.PromptGamePassPurchaseFinished`.
       - For **affiliate gear sales** or other assets, use


### PR DESCRIPTION
PromptProductPurchaseFinished had the deprecated tag added then removed but the description in the wiki still mentions it is deprecated

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
