### PR TITLE
Update LuaGlobals.yaml - Markdown Correction

### DIFF
--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -525,7 +525,7 @@ functions:
       Level 1 is the function calling `setfenv()`. `setfenv()` returns the given
       function.
 
-      If `f` is ` 0``, then  `setfenv()` changes the environment of the running
+      If `f` is `0`, then `setfenv()` changes the environment of the running
       thread and returns no values.
     parameters:
       - name: f


### PR DESCRIPTION
Markdown correction under global "setfenv"

I believe there was a small spelling mistake while typing the markdown for "setfenv", I was skimming over the Lua Global's documentation and just happened to see it.

Right now it looks like this: If `f` is ` 0``, then `setfenv()`
After the update it should like look like: If `f` is `0`, then `setfenv()`