### PR TITLE
Clarify that Read/Write methods use LE encoding

### DIFF
--- a/content/en-us/reference/engine/libraries/buffer.yaml
+++ b/content/en-us/reference/engine/libraries/buffer.yaml
@@ -27,6 +27,9 @@ description: |
   All offsets, counts and sizes should be non-negative integer numbers. If the
   bytes that are accessed by any read or write operation are outside the buffer
   memory, an error is thrown.
+
+  The `read` and `write` methods that work with integers and floats use
+  [little-endian](https://en.wikipedia.org/wiki/Endianness) encoding.
 code_samples:
 properties:
 functions:


### PR DESCRIPTION
## Changes

Clarify that `read` and `write` methods that use numbers use little-endian encoding. [[1]](https://github.com/Rerumu/luau/blob/d100d463573f385d837b75975afd593738b30fe6/rfcs/type-byte-buffer.md#design)

> Read and write operations for relevant types are little endian as it is the most common use case, and conversion is often trivial to do manually.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
