### PR TITLE
Update TextChannel.ShouldDeliverCallback

### DIFF
--- a/content/en-us/reference/engine/classes/TextChannel.yaml
+++ b/content/en-us/reference/engine/classes/TextChannel.yaml
@@ -183,24 +183,22 @@ callbacks:
     thread_safety: Unsafe
   - name: TextChannel.ShouldDeliverCallback
     summary: |
-      Called when `Class.TextChannel` is receiving an incoming message to
-      determine whether or not it should be delivered to other clients.
+      Called for each client when `Class.TextChannel` is receiving an incoming message to determine whether or not it should be delivered to that client.
     description: |
-      Called when `Class.TextChannel` is receiving an incoming message to
-      determine whether or not to deliver the message to other clients. Can only
-      be defined on the server.
+      Called for each client when `Class.TextChannel` is receiving an incoming message to determine whether or not it should be delivered to that client. Can only be defined on the server.
 
       Once defined, this callback needs to return a truthy value (true, 1,
-      "hello") to deliver the message to other clients. If the callback returns
-      anything else (including nil), the message can't be delivered. The sender
-      will still see the message even if the message can't be delivered.
+      "hello") to deliver the message to said client. If the callback returns
+      anything else (including nil), the message wont be delivered to that client. The sender will still see the message regardless.
+      
+      The sender can be refrenced by 'Class.TextChatMessage.TextSource'.
     code_samples: []
     parameters:
       - name: message
         type: TextChatMessage
         default:
         summary: ''
-      - name: textSource
+      - name: targetTextSource
         type: TextSource
         default:
         summary: ''


### PR DESCRIPTION
## Changes

Updated TextChannel.ShouldDeliverCallback to accurately describe what it does. Old documentation made it sound like it was called once per incoming message, when in reality it is called in succession for each receiving clients, and sender, when a message is sent.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
