### PR TITLE
Add tri/vertex limits to EditableMesh

### DIFF
--- a/content/en-us/reference/engine/classes/EditableMesh.yaml
+++ b/content/en-us/reference/engine/classes/EditableMesh.yaml
@@ -45,6 +45,11 @@ description: |
   go counterclockwise around it.
 
   <img src="/assets/engine-api/classes/EditableMesh/Winding.png" alt="Order of the vertices around the face" width="550" />
+
+  #### Limitations
+  `Class.EditableMesh` currently has a limit of 60,000 verticies and 20,000
+  triangles. Attempting to add too many verticies or triangles will cause an
+  error.
 code_samples: []
 inherits:
   - DataModelMesh

--- a/content/en-us/reference/engine/classes/EditableMesh.yaml
+++ b/content/en-us/reference/engine/classes/EditableMesh.yaml
@@ -47,8 +47,9 @@ description: |
   <img src="/assets/engine-api/classes/EditableMesh/Winding.png" alt="Order of the vertices around the face" width="550" />
 
   #### Limitations
-  `Class.EditableMesh` currently has a limit of 60,000 verticies and 20,000
-  triangles. Attempting to add too many verticies or triangles will cause an
+  
+  `Class.EditableMesh` currently has a limit of 60,000 vertices and 20,000
+  triangles. Attempting to add too many vertices or triangles will cause an
   error.
 code_samples: []
 inherits:


### PR DESCRIPTION
## Changes

Adds the limits for triangles and verticies on EditableMesh. (Source is me testing this by bruteforcing `AddVertex` and `AddTriangle`)

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
