### PR TITLE
CLI-88769 - Add API documentation for UnreliableRemoteEvents

### DIFF
--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -1,12 +1,12 @@
 name: UnreliableRemoteEvent
 type: class
-category:
+category: Scripting
 memory_category: Instances
 summary: |
   An object which facilitates asynchronous, unordered and unreliable, one-way communication across the
   client-server boundary. Scripts firing a `Class.UnreliableRemoteEvent` do not yield.
 description: |
-  The **UnreliableRemoteEvent** object is a variant of the RemoteEvent object. The UnreliableRemoteEvents facilitate asynchronous, unordered and unreliable, one-way communication
+  The **UnreliableRemoteEvent** object is a variant of the RemoteEvent object. UnreliableRemoteEvents facilitate asynchronous, unordered and unreliable, one-way communication
   across the [client-server](../../../projects/client-server.md) boundary
   without yielding for a response. This communication can be directed from one
   client to the server, from the server to a specific client, or from the server

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -3,10 +3,11 @@ type: class
 category:
 memory_category: Instances
 summary: |
-  An object which facilitates asynchronous, unordered and unreliable, one-way communication across the
+  An object which facilitates asynchronous, unordered/unreliable, one-way communication across the
   client-server boundary. Scripts firing a `Class.UnreliableRemoteEvent` do not yield.
 description: |
-  The **UnreliableRemoteEvent** object is a variant of the RemoteEvent object. UnreliableRemoteEvents facilitate asynchronous, unordered and unreliable, one-way communication
+  The **UnreliableRemoteEvent** object is a variant of the `Class.RemoteEvent` object.
+  It facilitates asynchronous, unordered/unreliable, one-way communication
   across the [client-server](../../../projects/client-server.md) boundary
   without yielding for a response. This communication can be directed from one
   client to the server, from the server to a specific client, or from the server
@@ -17,11 +18,11 @@ description: |
   `Class.ReplicatedStorage`, although in some cases it's appropriate to store it
   in `Class.Workspace` or inside a `Class.Tool`.
 
-  Unreliable remote events are best used for ephemeral events including effects that are only relevant for a short time, 
-  or for replicating continuously changing data. These events are not resent if they are lost, 
-  and they do not wait for previously fired events to arrive before being processed. 
-  This can result in reduced latency and network traffic.
-  When requiring ordering and reliability consider using a `Class.RemoteEvent` instead.
+  `Class.UnreliableRemoteEvent` is best used for ephemeral events including effects that
+  are only relevant for a short time, or for replicating continuously changing data. These
+  events are not resent if they are lost and they do not wait for previously fired events
+  to arrive before being processed, potentially resulting in reduced latency and network
+  traffic. When requiring ordering and reliability, use a `Class.RemoteEvent` instead.
 
   #### Parameter Limitations
 
@@ -30,7 +31,8 @@ description: |
   well as Luau types such as numbers, strings, and booleans, although you should
   carefully explore the
   [limitations](../../../scripting/events/remote.md#argument-limitations).
-  There is also a 900 byte limit to the payload of an `Class.UnreliableRemoteEvent`. Events with payloads larger than this will be dropped. See the corresponding method description for more details.
+  There is also a 900 byte limit to the payload of an `Class.UnreliableRemoteEvent`. Larger
+  payloads will be dropped. See the corresponding method description for more details.
 code_samples: []
 inherits:
   - BaseRemoteEvent

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -41,7 +41,7 @@ methods:
   - name: UnreliableRemoteEvent:FireAllClients
     summary: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for each
-      client connected to the same `Class.UnreliableRemoteEvent`.
+      client connected to the same `Class.UnreliableRemoteEvent`. Has a 900 byte limit to the payload of the event, otherwise event is dropped.
     description: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for each
       client connected to the same `Class.UnreliableRemoteEvent`. Unlike
@@ -76,7 +76,7 @@ methods:
   - name: UnreliableRemoteEvent:FireClient
     summary: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for a
-      specific client connected to the same `Class.UnreliableRemoteEvent`.
+      specific client connected to the same `Class.UnreliableRemoteEvent`. Has a 900 byte limit to the payload of the event, otherwise event is dropped.
     description: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for one
       connected client specified by the required `Class.Player` argument. Since
@@ -119,9 +119,7 @@ methods:
   - name: UnreliableRemoteEvent:FireServer
     summary: |
       Fires the `Class.UnreliableRemoteEvent.OnServerEvent|OnServerEvent` event on the
-      server from one client connected to the same `Class.UnreliableRemoteEvent`.
-
-      Note that there is a 900 byte limit to the payload of an UnreliableRemoteEvent. Events with payloads larger than this will be dropped. When this happens in RobloxStudio, we will output a log message in the output menu       indicating how many bytes the event has gone over.
+      server from one client connected to the same `Class.UnreliableRemoteEvent`. Has a 900 byte limit to the payload of the event, otherwise event is dropped.
     description: |
       Fires the `Class.UnreliableRemoteEvent.OnServerEvent|OnServerEvent` event on the
       server from one client. Connected events receive the `Class.Player`
@@ -158,7 +156,7 @@ events:
       Fires from a `Class.LocalScript` when either
       `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
       `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` is called on the
-      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`.
+      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`. Not guaranteed to fire if one of the above methods are called. This can occur due to packet loss or to maintain optimal engine performance.
     description: |
       Fires from a `Class.LocalScript` when either
       `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
@@ -185,9 +183,7 @@ events:
     summary: |
       Fires from a `Class.Script` when
       `Class.UnreliableRemoteEvent:FireServer()|FireServer()` is called on the same
-      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`.
-
-      Note that due to the unreliable nature of UnreliableRemoteEvents it is not guaranteed that the signal will fire if you call one of FireClient(), FireAllClients() or FireSever(). This can occur due to packet loss or to       maintain optimal engine performance.
+      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`. Not guaranteed to fire if the above method is called. This can occur due to packet loss or to maintain optimal engine performance.
     description: |
       Fires from a `Class.Script` when
       `Class.UnreliableRemoteEvent:FireServer()|FireServer()` is called on the same

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -1,6 +1,6 @@
 name: UnreliableRemoteEvent
 type: class
-category: Scripting
+category:
 memory_category: Instances
 summary: |
   An object which facilitates asynchronous, unordered and unreliable, one-way communication across the

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -179,7 +179,9 @@ events:
       this firing is not guaranteed even if one of the above methods are called. This
       can occur due to packet loss or to maintain optimal engine performance.
 
-      It is not guaranteed that the order of events will match the order of FireServer() calls.
+      Also note that it is not guaranteed that the order of events will match the
+      order of `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
+      `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` calls.
     code_samples: []
     parameters:
       - name: arguments

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -207,7 +207,8 @@ events:
       this firing is not guaranteed even if the above methods is called. This
       can occur due to packet loss or to maintain optimal engine performance.
       
-      It is not guaranteed that the order of events will match the order of FireServer() calls.
+      Also note that it is not guaranteed that the order of events will match the order
+      of `Class.UnreliableRemoteEvent:FireServer()|FireServer()` calls.
     code_samples: []
     parameters:
       - name: player

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -3,8 +3,9 @@ type: class
 category:
 memory_category: Instances
 summary: |
-  An object which facilitates asynchronous, unordered/unreliable, one-way communication across the
-  client-server boundary. Scripts firing a `Class.UnreliableRemoteEvent` do not yield.
+  An object which facilitates asynchronous, unordered/unreliable, one-way communication
+  across the client-server boundary. Scripts firing a `Class.UnreliableRemoteEvent` do
+  not yield.
 description: |
   The **UnreliableRemoteEvent** object is a variant of the `Class.RemoteEvent` object.
   It facilitates asynchronous, unordered/unreliable, one-way communication
@@ -167,16 +168,16 @@ events:
       Fires from a `Class.LocalScript` when either
       `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
       `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` is called on the
-      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`. Not
-      guaranteed to fire if one of the above methods are called. This can occur due
-      to packet loss or to maintain optimal engine performance.
+      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`, although
+      this firing is not guaranteed even if one of the above methods are called. This
+      can occur due to packet loss or to maintain optimal engine performance.
     description: |
       Fires from a `Class.LocalScript` when either
       `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
       `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` is called on the
-      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`.
-
-      It is not guaranteed that the event will fire if FireClient() or FireAllClients() is called as the event may be dropped due to packet loss or to maintain optimal engine performance.
+      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`, although
+      this firing is not guaranteed even if one of the above methods are called. This
+      can occur due to packet loss or to maintain optimal engine performance.
 
       It is not guaranteed that the order of events will match the order of FireServer() calls.
     code_samples: []
@@ -196,13 +197,15 @@ events:
     summary: |
       Fires from a `Class.Script` when
       `Class.UnreliableRemoteEvent:FireServer()|FireServer()` is called on the same
-      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`. Not guaranteed to fire if the above method is called. This can occur due to packet loss or to maintain optimal engine performance.
+      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`, although
+      this firing is not guaranteed even if the above methods is called. This
+      can occur due to packet loss or to maintain optimal engine performance.
     description: |
       Fires from a `Class.Script` when
       `Class.UnreliableRemoteEvent:FireServer()|FireServer()` is called on the same
-      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`.
-
-      It is not guaranteed that the event will fire if FireServer() is called as the event may be dropped due to packet loss or to maintain optimal engine performance.
+      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`, although
+      this firing is not guaranteed even if the above methods is called. This
+      can occur due to packet loss or to maintain optimal engine performance.
       
       It is not guaranteed that the order of events will match the order of FireServer() calls.
     code_samples: []

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -3,12 +3,12 @@ type: class
 category:
 memory_category: Instances
 summary: |
-  An object which facilitates asynchronous, unordered/unreliable, one-way communication
+  An object which facilitates asynchronous, unordered and unreliable, one-way communication
   across the client-server boundary. Scripts firing a `Class.UnreliableRemoteEvent` do
   not yield.
 description: |
   The **UnreliableRemoteEvent** object is a variant of the `Class.RemoteEvent` object.
-  It facilitates asynchronous, unordered/unreliable, one-way communication
+  It facilitates asynchronous, unordered and unreliable, one-way communication
   across the [client-server](../../../projects/client-server.md) boundary
   without yielding for a response. This communication can be directed from one
   client to the server, from the server to a specific client, or from the server

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -2,9 +2,36 @@ name: UnreliableRemoteEvent
 type: class
 category:
 memory_category: Instances
-summary: ''
-description: ''
-code_samples: []
+summary: |
+  An object which facilitates asynchronous, unordered and unreliable, one-way communication across the
+  client-server boundary. Scripts firing a `Class.UnreliableRemoteEvent` do not yield.
+description: |
+  The **UnreliableRemoteEvent** object is a variant of the RemoteEvent object. The UnreliableRemoteEvents facilitate asynchronous, unordered and unreliable, one-way communication
+  across the [client-server](../../../projects/client-server.md) boundary
+  without yielding for a response. This communication can be directed from one
+  client to the server, from the server to a specific client, or from the server
+  to all clients.
+
+  In order for both the server and clients to access a `Class.UnreliableRemoteEvent`
+  instance, it must be in a place where both sides can see it, such as
+  `Class.ReplicatedStorage`, although in some cases it's appropriate to store it
+  in `Class.Workspace` or inside a `Class.Tool`.
+
+  Unreliable remote events are best used for ephemeral events including effects that are only relevant for a short time, 
+  or for replicating continuously changing data. These events are not resent if they are lost, 
+  and they do not wait for previously fired events to arrive before being processed. 
+  This can result in reduced latency and network traffic.
+  When requiring ordering and reliability consider using a `Class.RemoteEvent` instead.
+
+  #### Parameter Limitations
+
+  Any type of Roblox object such as an `Datatype.Enum`, `Class.Instance`, or
+  others can be passed as a parameter when a `Class.UnreliableRemoteEvent` is fired, as
+  well as Luau types such as numbers, strings, and booleans, although you should
+  carefully explore the
+  [limitations](../../../scripting/events/remote.md#argument-limitations).
+  There is also a 900 byte limit to the payload of an `Class.UnreliableRemoteEvent`. Events with payloads larger than this will be dropped. See the corresponding method description for more details.
+code_samples:
 inherits:
   - BaseRemoteEvent
 tags: []
@@ -12,14 +39,33 @@ deprecation_message: ''
 properties: []
 methods:
   - name: UnreliableRemoteEvent:FireAllClients
-    summary: ''
-    description: ''
-    code_samples: []
+    summary: |
+      Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for each
+      client connected to the same `Class.UnreliableRemoteEvent`.
+    description: |
+      Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for each
+      client connected to the same `Class.UnreliableRemoteEvent`. Unlike
+      `Class.UnreliableRemoteEvent:FireClient()|FireClient()`, this event does not take a
+      target `Class.Player` as the first argument, since it fires to multiple
+      clients. Since this method is used to communicate from the server to
+      clients, it will only work when used in a `Class.Script`.
+
+      Any type of Roblox object such as an `Datatype.Enum`, `Class.Instance`, or
+      others can be passed as a parameter to
+      `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()`, as well as Luau
+      types such as numbers, strings, and booleans, although you should
+      carefully explore the
+      [limitations](../../../scripting/events/remote.md#argument-limitations).
+
+      Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
+    code_samples:
     parameters:
       - name: arguments
         type: Tuple
         default:
-        summary: ''
+        summary: |
+          Values to pass to all `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent`
+          events connected to the same `Class.UnreliableRemoteEvent`.
     returns:
       - type: void
         summary: ''
@@ -28,18 +74,41 @@ methods:
     security: None
     thread_safety: Unsafe
   - name: UnreliableRemoteEvent:FireClient
-    summary: ''
-    description: ''
-    code_samples: []
+    summary: |
+      Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for a
+      specific client connected to the same `Class.UnreliableRemoteEvent`.
+    description: |
+      Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for one
+      connected client specified by the required `Class.Player` argument. Since
+      this method is used to communicate from the server to a client, it will
+      only work when used in a `Class.Script`.
+
+      Any type of Roblox object such as an `Datatype.Enum`, `Class.Instance`, or
+      others can be passed as a parameter to
+      `Class.UnreliableRemoteEvent:FireClient()|FireClient()`, as well as Luau types such
+      as numbers, strings, and booleans, although you should carefully explore
+      the
+      [limitations](../../../scripting/events/remote.md#argument-limitations).
+
+      Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
+      
+      See also
+      `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` which works
+      similarly but fires the event for each client connected to the same
+      `Class.UnreliableRemoteEvent`.
+    code_samples:
     parameters:
       - name: player
         type: Player
         default:
-        summary: ''
+        summary: |
+          The client of the `Class.Player` to fire the event to.
       - name: arguments
         type: Tuple
         default:
-        summary: ''
+        summary: |
+          Values to pass to `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent`
+          events connected to the same `Class.UnreliableRemoteEvent`.
     returns:
       - type: void
         summary: ''
@@ -48,14 +117,34 @@ methods:
     security: None
     thread_safety: Unsafe
   - name: UnreliableRemoteEvent:FireServer
-    summary: ''
-    description: ''
-    code_samples: []
+    summary: |
+      Fires the `Class.UnreliableRemoteEvent.OnServerEvent|OnServerEvent` event on the
+      server from one client connected to the same `Class.UnreliableRemoteEvent`.
+
+      Note that there is a 900 byte limit to the payload of an UnreliableRemoteEvent. Events with payloads larger than this will be dropped. When this happens in RobloxStudio, we will output a log message in the output menu       indicating how many bytes the event has gone over.
+    description: |
+      Fires the `Class.UnreliableRemoteEvent.OnServerEvent|OnServerEvent` event on the
+      server from one client. Connected events receive the `Class.Player`
+      argument of the firing client. Since this method is used to communicate
+      from a client to the server, it will only work when used in a
+      `Class.LocalScript`.
+
+      Any type of Roblox object such as an `Datatype.Enum`, `Class.Instance`, or
+      others can be passed as a parameter to
+      `Class.UnreliableRemoteEvent:FireServer()|FireServer()`, as well as Luau types such
+      as numbers, strings, and booleans, although you should carefully explore
+      the
+      [limitations](../../../scripting/events/remote.md#argument-limitations).
+
+      Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
+    code_samples:
     parameters:
       - name: arguments
         type: Tuple
         default:
-        summary: ''
+        summary: |
+          Values to pass to `Class.UnreliableRemoteEvent.OnServerEvent|OnServerEvent`
+          events connected to the same `Class.UnreliableRemoteEvent`.
     returns:
       - type: void
         summary: ''
@@ -65,31 +154,62 @@ methods:
     thread_safety: Unsafe
 events:
   - name: UnreliableRemoteEvent.OnClientEvent
-    summary: ''
-    description: ''
-    code_samples: []
+    summary: |
+      Fires from a `Class.LocalScript` when either
+      `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
+      `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` is called on the
+      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`.
+    description: |
+      Fires from a `Class.LocalScript` when either
+      `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
+      `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` is called on the
+      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`.
+
+      It is not guaranteed that the event will fire if FireClient() or FireAllClients() is called as the event may be dropped due to packet loss or to maintain optimal engine performance.
+
+      It is not guaranteed that the order of events will match the order of FireServer() calls.
+    code_samples:
     parameters:
       - name: arguments
         type: Tuple
         default:
-        summary: ''
+        summary: |
+          The parameters sent through
+          `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
+          `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()`.
     tags: []
     deprecation_message: ''
     security: None
     thread_safety: Unsafe
   - name: UnreliableRemoteEvent.OnServerEvent
-    summary: ''
-    description: ''
-    code_samples: []
+    summary: |
+      Fires from a `Class.Script` when
+      `Class.UnreliableRemoteEvent:FireServer()|FireServer()` is called on the same
+      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`.
+
+      Note that due to the unreliable nature of UnreliableRemoteEvents it is not guaranteed that the signal will fire if you call one of FireClient(), FireAllClients() or FireSever(). This can occur due to packet loss or to       maintain optimal engine performance.
+    description: |
+      Fires from a `Class.Script` when
+      `Class.UnreliableRemoteEvent:FireServer()|FireServer()` is called on the same
+      `Class.UnreliableRemoteEvent` instance from a `Class.LocalScript`.
+
+      It is not guaranteed that the event will fire if FireServer() is called as the event may be dropped due to packet loss or to maintain optimal engine performance.
+      
+      It is not guaranteed that the order of events will match the order of FireServer() calls.
+    code_samples:
     parameters:
       - name: player
         type: Player
         default:
-        summary: ''
+        summary: |
+          The `Class.Player` associated with the client that the
+          `Class.UnreliableRemoteEvent:FireServer()|FireServer()` call originates from.
       - name: arguments
         type: Tuple
         default:
-        summary: ''
+        summary: |
+          The parameters sent through
+          `Class.UnreliableRemoteEvent:FireServer()|FireServer()`.
     tags: []
     deprecation_message: ''
     security: None

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -43,7 +43,8 @@ methods:
   - name: UnreliableRemoteEvent:FireAllClients
     summary: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for each
-      client connected to the same `Class.UnreliableRemoteEvent`. Has a 900 byte limit to the payload of the event, otherwise event is dropped.
+      client connected to the same `Class.UnreliableRemoteEvent`. Has a 900 byte limit to
+      the payload of the event, otherwise event is dropped.
     description: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for each
       client connected to the same `Class.UnreliableRemoteEvent`. Unlike
@@ -59,7 +60,9 @@ methods:
       carefully explore the
       [limitations](../../../scripting/events/remote.md#argument-limitations).
 
-      Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
+      Events with payloads larger than 900 bytes will be dropped. When this happens in Studio,
+      a log message in the [Output](../../../studio/output.md) window will indicate by how many
+      bytes the event has gone over.
     code_samples: []
     parameters:
       - name: arguments
@@ -78,7 +81,8 @@ methods:
   - name: UnreliableRemoteEvent:FireClient
     summary: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for a
-      specific client connected to the same `Class.UnreliableRemoteEvent`. Has a 900 byte limit to the payload of the event, otherwise event is dropped.
+      specific client connected to the same `Class.UnreliableRemoteEvent`. Has a 900
+      byte limit to the payload of the event, otherwise event is dropped.
     description: |
       Fires the `Class.UnreliableRemoteEvent.OnClientEvent|OnClientEvent` event for one
       connected client specified by the required `Class.Player` argument. Since
@@ -92,7 +96,9 @@ methods:
       the
       [limitations](../../../scripting/events/remote.md#argument-limitations).
 
-      Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
+      Events with payloads larger than 900 bytes will be dropped. When this happens in Studio,
+      a log message in the [Output](../../../studio/output.md) window will indicate by how many
+      bytes the event has gone over.
       
       See also
       `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` which works
@@ -121,7 +127,8 @@ methods:
   - name: UnreliableRemoteEvent:FireServer
     summary: |
       Fires the `Class.UnreliableRemoteEvent.OnServerEvent|OnServerEvent` event on the
-      server from one client connected to the same `Class.UnreliableRemoteEvent`. Has a 900 byte limit to the payload of the event, otherwise event is dropped.
+      server from one client connected to the same `Class.UnreliableRemoteEvent`. Has a
+      900 byte limit to the payload of the event, otherwise event is dropped.
     description: |
       Fires the `Class.UnreliableRemoteEvent.OnServerEvent|OnServerEvent` event on the
       server from one client. Connected events receive the `Class.Player`
@@ -136,7 +143,9 @@ methods:
       the
       [limitations](../../../scripting/events/remote.md#argument-limitations).
 
-      Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
+      Events with payloads larger than 900 bytes will be dropped. When this happens in Studio,
+      a log message in the [Output](../../../studio/output.md) window will indicate by how many
+      bytes the event has gone over.
     code_samples: []
     parameters:
       - name: arguments
@@ -158,7 +167,9 @@ events:
       Fires from a `Class.LocalScript` when either
       `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or
       `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` is called on the
-      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`. Not guaranteed to fire if one of the above methods are called. This can occur due to packet loss or to maintain optimal engine performance.
+      same `Class.UnreliableRemoteEvent` instance from a `Class.Script`. Not
+      guaranteed to fire if one of the above methods are called. This can occur due
+      to packet loss or to maintain optimal engine performance.
     description: |
       Fires from a `Class.LocalScript` when either
       `Class.UnreliableRemoteEvent:FireClient()|FireClient()` or

--- a/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
+++ b/content/en-us/reference/engine/classes/UnreliableRemoteEvent.yaml
@@ -31,7 +31,7 @@ description: |
   carefully explore the
   [limitations](../../../scripting/events/remote.md#argument-limitations).
   There is also a 900 byte limit to the payload of an `Class.UnreliableRemoteEvent`. Events with payloads larger than this will be dropped. See the corresponding method description for more details.
-code_samples:
+code_samples: []
 inherits:
   - BaseRemoteEvent
 tags: []
@@ -58,7 +58,7 @@ methods:
       [limitations](../../../scripting/events/remote.md#argument-limitations).
 
       Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
-    code_samples:
+    code_samples: []
     parameters:
       - name: arguments
         type: Tuple
@@ -96,7 +96,7 @@ methods:
       `Class.UnreliableRemoteEvent:FireAllClients()|FireAllClients()` which works
       similarly but fires the event for each client connected to the same
       `Class.UnreliableRemoteEvent`.
-    code_samples:
+    code_samples: []
     parameters:
       - name: player
         type: Player
@@ -137,7 +137,7 @@ methods:
       [limitations](../../../scripting/events/remote.md#argument-limitations).
 
       Events with payloads larger than 900 bytes will be dropped. When this happens in RobloxStudio, a log message in the output menu will indicate by how many bytes the event has gone over.
-    code_samples:
+    code_samples: []
     parameters:
       - name: arguments
         type: Tuple
@@ -168,7 +168,7 @@ events:
       It is not guaranteed that the event will fire if FireClient() or FireAllClients() is called as the event may be dropped due to packet loss or to maintain optimal engine performance.
 
       It is not guaranteed that the order of events will match the order of FireServer() calls.
-    code_samples:
+    code_samples: []
     parameters:
       - name: arguments
         type: Tuple
@@ -196,7 +196,7 @@ events:
       It is not guaranteed that the event will fire if FireServer() is called as the event may be dropped due to packet loss or to maintain optimal engine performance.
       
       It is not guaranteed that the order of events will match the order of FireServer() calls.
-    code_samples:
+    code_samples: []
     parameters:
       - name: player
         type: Player


### PR DESCRIPTION

## Changes

Add V1 description of UnreliableRemoteEvents. Note that much of this is the same as RemoteEvents and was ported over with minor changes. This is because this new instance is a variant of the RemoteEvent instance.

Essentially what I did was added how this instance differs from RemoteEvents + added the caveats that developers should be aware of when using UREs.

https://devforum.roblox.com/t/introducing-unreliableremoteevents/2724155

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
