### PR TITLE
Update SelectionSphere.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/SelectionSphere.yaml
+++ b/content/en-us/reference/engine/classes/SelectionSphere.yaml
@@ -14,14 +14,14 @@ description: |
   <img src="/assets/legacy/SelectionSphere.jpg" alt="A default SelectionSphere adorned to a semi-transparent default Part"  />
   There are a few properties available to configure the appearance of the
   sphere. The outline can modified through the
-  `Class.GuiBase3d.Color3|Color3`&dagger; and
-  `Class.GuiBase3d.Transparency|Transparency`&dagger; properties. The surface can
+  `Class.GuiBase3d.Color3|Color3`; and
+  `Class.GuiBase3d.Transparency|Transparency`; properties. The surface can
   be modified through the `Class.SelectionSphere.SurfaceColor3|SurfaceColor3` and
   `Class.SelectionSphere.SurfaceTransparency|SurfaceTransparency` properties.
   Finally, rendering of the sphere can be toggled with the
-  `Class.GuiBase3d.Visible|Visible`&dagger; property.
+  `Class.GuiBase3d.Visible|Visible`; property.
 
-  &dagger; These properties come from this object's superclass,
+  ; These properties come from this object's superclass,
   `Class.GuiBase3d`.
 
   The SelectionSphere object does not capture any form of input; it is solely a

--- a/content/en-us/reference/engine/classes/SelectionSphere.yaml
+++ b/content/en-us/reference/engine/classes/SelectionSphere.yaml
@@ -11,17 +11,15 @@ description: |
   geometry consists of a ring/outline in addition to a surface. By default, only
   the outline is visible.
 
-  <img src="/assets/legacy/SelectionSphere.jpg" alt="A default SelectionSphere adorned to a semi-transparent default Part"  />
   There are a few properties available to configure the appearance of the
   sphere. The outline can modified through the
-  `Class.GuiBase3d.Color3|Color3`; and
-  `Class.GuiBase3d.Transparency|Transparency`; properties. The surface can
+  `Class.GuiBase3d.Color3` and
+  `Class.GuiBase3d.Transparency` properties. The surface can
   be modified through the `Class.SelectionSphere.SurfaceColor3|SurfaceColor3` and
   `Class.SelectionSphere.SurfaceTransparency|SurfaceTransparency` properties.
   Finally, rendering of the sphere can be toggled with the
-  `Class.GuiBase3d.Visible|Visible`; property.
+  `Class.GuiBase3d.Visible` property.
 
-  ; These properties come from this object's superclass,
   `Class.GuiBase3d`.
 
   The SelectionSphere object does not capture any form of input; it is solely a


### PR DESCRIPTION
I have no idea why the crosses are there, but they appear to be messing with the formatting.

## Changes

<!-- Please summarize your changes. -->
Removing "Daggers" that appear as crosses on Google Chrome.
<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
This is what it currently looks like on my end:
![image](https://github.com/Roblox/creator-docs/assets/85803876/8162e98a-4d1a-4849-bc67-842751b1f141)
## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.