### PR TITLE
Correct description of global unpack's parameters

### DIFF
--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -686,7 +686,7 @@ functions:
         type: int
         default: '#list'
         summary: |
-          The index of the last element to unpack.
+          The number of elements to unpack.
     returns:
       - type: Variant
         summary: ''

--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -55,7 +55,7 @@ functions:
       - type: Variant
         summary: ''
     tags:
-    code_samples:
+    codesamples:
   - name: collectgarbage
     summary: |
       Performs the specified operation of the garbage collector.
@@ -78,7 +78,7 @@ functions:
       - type: Variant
         summary: ''
     tags:
-    code_samples:
+    codesamples:
   - name: error
     summary: |
       Halts thread execution and throws an error.
@@ -614,7 +614,7 @@ functions:
         type: int
         default: 10
         summary: |
-          The numerical base to convert _arg_ into.
+          The numerical base to convert `arg` into.
     returns:
       - type: Variant
         summary: ''
@@ -669,8 +669,8 @@ functions:
     summary: |
       Returns all elements from the given list as a tuple.
     description: |
-      Returns the elements from the given table. By default, _i_ is 1 and _j_ is
-      the length of _list_, as defined by the length operator.
+      Returns the elements from the given table. By default, `i` is 1 and `j` is
+      the length of `list`, as defined by the length operator.
     parameters:
       - name: list
         type: table

--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -55,7 +55,7 @@ functions:
       - type: Variant
         summary: ''
     tags:
-    codesamples:
+    code_samples:
   - name: collectgarbage
     summary: |
       Performs the specified operation of the garbage collector.
@@ -78,7 +78,7 @@ functions:
       - type: Variant
         summary: ''
     tags:
-    codesamples:
+    code_samples:
   - name: error
     summary: |
       Halts thread execution and throws an error.

--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -681,12 +681,12 @@ functions:
         type: int
         default: 1
         summary: |
-          The starting index to unpack from.
+          The index of the first element to unpack.
       - name: j
         type: int
         default: '#list'
         summary: |
-          The number of elements to unpack.
+          The index of the last element to unpack.
     returns:
       - type: Variant
         summary: ''


### PR DESCRIPTION
Correct the description of the unpack parameters.

## Changes

The description of `unpack`'s `j` parameter was wrong. It is not a count, it is the index of the last element to `unpack`. Updated the description of the `i` parameter to match the new wording of the `j` parameter.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
