### PR TITLE
Updated CollectionService to reflect engine updates

### DIFF
--- a/content/en-us/reference/engine/classes/CollectionService.yaml
+++ b/content/en-us/reference/engine/classes/CollectionService.yaml
@@ -8,9 +8,8 @@ description: |
   The `Class.CollectionService` manages groups (collections) of instances with
   tags. Tags are sets of strings applied to objects that replicate from the
   server to the client and in Team Create. They are also serialized when places
-  are saved. At the moment, tags are not visible within Roblox Studio except
-  with the use of a tag-editing plugin. You may see all the tags applied to any
-  object by selecting it and going to the tags section in the properties panel
+  are saved. You may see all of the tags applied to an object by selecting it
+  and scrolling down to the tags section in the property browser.
 
   The primary use of `Class.CollectionService` is to register instances with
   specific tags that you can use to extend their behavior. If you find yourself

--- a/content/en-us/reference/engine/classes/CollectionService.yaml
+++ b/content/en-us/reference/engine/classes/CollectionService.yaml
@@ -9,7 +9,8 @@ description: |
   tags. Tags are sets of strings applied to objects that replicate from the
   server to the client and in Team Create. They are also serialized when places
   are saved. At the moment, tags are not visible within Roblox Studio except
-  with the use of a tag-editing plugin.
+  with the use of a tag-editing plugin. You may see all the tags applied to any
+  object by selecting it and going to the tags section in the properties panel
 
   The primary use of `Class.CollectionService` is to register instances with
   specific tags that you can use to extend their behavior. If you find yourself


### PR DESCRIPTION
## Changes

Updated the first paragraph of the `CollectionService` page to reflect recent engine updates, describing how to view tags in the property browser.

Devforum post where they announced they had launched the feature:
https://devforum.roblox.com/t/add-and-remove-tags-from-the-properties-panel-beta/2506442/70

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
