### PR TITLE
Update PackageLink.yaml - minor issue

### DIFF
--- a/content/en-us/reference/engine/classes/PackageLink.yaml
+++ b/content/en-us/reference/engine/classes/PackageLink.yaml
@@ -6,7 +6,7 @@ summary: |
   Links a `Class.DataModel` instance to a corresponding asset in the cloud.
 description: |
   The purpose of the `Class.PackageLink` object is to link a `Class.DataModel`
-  instance to a corresponding asset in the cloud. This improves flows for\
+  instance to a corresponding asset in the cloud. This improves flows for
   collaboration, version control, and sharing for models. The `Class.PackageLink`
   instance will be a child of the root of the entire package hierarchy.
 

--- a/content/en-us/reference/engine/classes/PackageLink.yaml
+++ b/content/en-us/reference/engine/classes/PackageLink.yaml
@@ -5,21 +5,16 @@ memory_category: Instances
 summary: |
   Links a `Class.DataModel` instance to a corresponding asset in the cloud.
 description: |
-  The purpose of the PackageLink object is to link a `Class.DataModel` instance
-  to a corresponding asset in the cloud. This improves flows for collaboration,
-  version control and sharing for models. The PackageLink instance will be a
-  child of the root of the entire package hierarchy.
+  The purpose of the `Class.PackageLink` object is to link a `Class.DataModel`
+  instance to a corresponding asset in the cloud. This improves flows for\
+  collaboration, version control, and sharing for models. The `Class.PackageLink`
+  instance will be a child of the root of the entire package hierarchy.
 
-  ![PackageLink in Studio Explorer](/assets/legacy/PackageLink.jpg)
-
-  In this case PackageLink designates `Class.Model` to be the root of the
-  Package hierarchy.
-
-  They are not creatable through `Class.Script|scripts`. They can only be added
-  through interaction with Studio and can only be parented to
-  `Class.Instance|Instances` that can be published independently of DataModel
-  publish. The PackageLink instance will always be the first child shown in the
-  tree view, regardless of sorting.
+  `Class.PackageLink|PackageLinks` are not creatable through `Class.Script|Scripts`.
+  They can only be added through interaction with Studio and can only be parented to
+  `Class.Instance|Instances` that can be published independently of `Class.DataModel`
+  publish. The `Class.PackageLink` instance will always be the first child shown in
+  the tree view, regardless of sorting.
 code_samples:
 inherits:
   - Instance

--- a/content/en-us/reference/engine/classes/PackageLink.yaml
+++ b/content/en-us/reference/engine/classes/PackageLink.yaml
@@ -15,7 +15,7 @@ description: |
   In this case PackageLink designates `Class.Model` to be the root of the
   Package hierarchy.
 
-  They not creatable through `Class.Script|scripts`. They can only be added
+  They are not creatable through `Class.Script|scripts`. They can only be added
   through interaction with Studio and can only be parented to
   `Class.Instance|Instances` that can be published independently of DataModel
   publish. The PackageLink instance will always be the first child shown in the


### PR DESCRIPTION
## Changes

Minor grammatical issue, you forgot to add "are" in the sentence "They **are** not creatable through `Class.Script|scripts`."

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
