### PR TITLE
Fix markdown for CreateDefaultCommands in TextChatService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -68,14 +68,14 @@ properties:
       created and put in a `Class.Folder` named **TextChatCommands** inside
       `Class.TextChatService`:
 
-      | Name              | PrimaryAlias | SecondaryAlias | Description                                                                                          | Usage Example  |
-      | :---------------- | :----------- | :------------- | :--------------------------------------------------------------------------------------------------- | :------------- | -------------- |
-      | RBXConsoleCommand | console      |                | Opens the Developer Console.                                                                         | `\console`     |
-      | RBXEmoteCommand   | emote        | e              | Plays avatar emote.                                                                                  | `\e dance`     |
-      | RBXHelpCommand    | help         | ?              | Shows a list of chat commands.                                                                       | `\help`        |
-      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel   | TextChannels`. | `\m Username`  |
+      | Name              | PrimaryAlias | SecondaryAlias | Description                                                                                                           | Usage Example  |
+      | :---------------- | :----------- | :------------- | :-------------------------------------------------------------------------------------------------------------------- | :------------- |
+      | RBXConsoleCommand | console      |                | Opens the Developer Console.                                                                                          | `\console`     |
+      | RBXEmoteCommand   | emote        | e              | Plays avatar emote.                                                                                                   | `\e dance`     |
+      | RBXHelpCommand    | help         | ?              | Shows a list of chat commands.                                                                                        | `\help`        |
+      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel | TextChannels`.   | `\m Username`  |
       | RBXUnmuteCommand  | unmute       | um             | Unmutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel | TextChannels`. | `\um Username` |
-      | RBXVersionCommand | version      | v              | Shows the chat version.                                                                              | `\version`     |
+      | RBXVersionCommand | version      | v              | Shows the chat version.                                                                                               | `\version`     |
 
       Developers can edit, create, and remove
       `Class.TextChatCommand|TextChatCommands` as even if


### PR DESCRIPTION
## Changes

This attempts to fix the markdown formatting for the CreateDefaultCommands in `TextChatService.yaml`. I say this because I'm unsure of whether this fixes the markdown issue or not since I cannot seem to test it.

I believe the markdown was written wrong because of `Class.TextChannel | TextChannels`

This is what it looks like right now on the docs:

![BrokenMarkdown](https://github.com/Roblox/creator-docs/assets/19847497/aba902e6-ceab-470b-bbed-6852009eb77d)


## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
