### PR TITLE
Add markdown escape to TextChatService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -68,14 +68,14 @@ properties:
       created and put in a `Class.Folder` named **TextChatCommands** inside
       `Class.TextChatService`:
 
-      | Name              | PrimaryAlias | SecondaryAlias | Description                                                                                          | Usage Example  |
-      | :---------------- | :----------- | :------------- | :--------------------------------------------------------------------------------------------------- | :------------- | -------------- |
-      | RBXConsoleCommand | console      |                | Opens the Developer Console.                                                                         | `\console`     |
-      | RBXEmoteCommand   | emote        | e              | Plays avatar emote.                                                                                  | `\e dance`     |
-      | RBXHelpCommand    | help         | ?              | Shows a list of chat commands.                                                                       | `\help`        |
-      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel   | TextChannels`. | `\m Username`  |
+      | Name              | PrimaryAlias | SecondaryAlias | Description                                                                                                           | Usage Example  |
+      | :---------------- | :----------- | :------------- | :-------------------------------------------------------------------------------------------------------------------- | :------------- |
+      | RBXConsoleCommand | console      |                | Opens the Developer Console.                                                                                          | `\console`     |
+      | RBXEmoteCommand   | emote        | e              | Plays avatar emote.                                                                                                   | `\e dance`     |
+      | RBXHelpCommand    | help         | ?              | Shows a list of chat commands.                                                                                        | `\help`        |
+      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel | TextChannels`.   | `\m Username`  |
       | RBXUnmuteCommand  | unmute       | um             | Unmutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel | TextChannels`. | `\um Username` |
-      | RBXVersionCommand | version      | v              | Shows the chat version.                                                                              | `\version`     |
+      | RBXVersionCommand | version      | v              | Shows the chat version.                                                                                               | `\version`     |
 
       Developers can edit, create, and remove
       `Class.TextChatCommand|TextChatCommands` as even if

--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -68,14 +68,14 @@ properties:
       created and put in a `Class.Folder` named **TextChatCommands** inside
       `Class.TextChatService`:
 
-      | Name              | PrimaryAlias | SecondaryAlias | Description                                                                                                           | Usage Example  |
-      | :---------------- | :----------- | :------------- | :-------------------------------------------------------------------------------------------------------------------- | :------------- |
-      | RBXConsoleCommand | console      |                | Opens the Developer Console.                                                                                          | `\console`     |
-      | RBXEmoteCommand   | emote        | e              | Plays avatar emote.                                                                                                   | `\e dance`     |
-      | RBXHelpCommand    | help         | ?              | Shows a list of chat commands.                                                                                        | `\help`        |
-      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel | TextChannels`.   | `\m Username`  |
-      | RBXUnmuteCommand  | unmute       | um             | Unmutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel | TextChannels`. | `\um Username` |
-      | RBXVersionCommand | version      | v              | Shows the chat version.                                                                                               | `\version`     |
+      | Name              | PrimaryAlias | SecondaryAlias | Description                                                                                                            | Usage Example  |
+      | :---------------- | :----------- | :------------- | :--------------------------------------------------------------------------------------------------------------------- | :------------- |
+      | RBXConsoleCommand | console      |                | Opens the Developer Console.                                                                                           | `\console`     |
+      | RBXEmoteCommand   | emote        | e              | Plays avatar emote.                                                                                                    | `\e dance`     |
+      | RBXHelpCommand    | help         | ?              | Shows a list of chat commands.                                                                                         | `\help`        |
+      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel \| TextChannels`.   | `\m Username`  |
+      | RBXUnmuteCommand  | unmute       | um             | Unmutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel \| TextChannels`. | `\um Username` |
+      | RBXVersionCommand | version      | v              | Shows the chat version.                                                                                                | `\version`     |
 
       Developers can edit, create, and remove
       `Class.TextChatCommand|TextChatCommands` as even if

--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -73,8 +73,8 @@ properties:
       | RBXConsoleCommand | console      |                | Opens the Developer Console.                                                                                           | `\console`     |
       | RBXEmoteCommand   | emote        | e              | Plays avatar emote.                                                                                                    | `\e dance`     |
       | RBXHelpCommand    | help         | ?              | Shows a list of chat commands.                                                                                         | `\help`        |
-      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel \| TextChannels`.   | `\m Username`  |
-      | RBXUnmuteCommand  | unmute       | um             | Unmutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel \| TextChannels`. | `\um Username` |
+      | RBXMuteCommand    | mute         | m              | Mutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel\|TextChannels`.   | `\m Username`  |
+      | RBXUnmuteCommand  | unmute       | um             | Unmutes a user by user's `Class.Player.Name` or `Class.Player.DisplayName` in all `Class.TextChannel\|TextChannels`. | `\um Username` |
       | RBXVersionCommand | version      | v              | Shows the chat version.                                                                                                | `\version`     |
 
       Developers can edit, create, and remove


### PR DESCRIPTION
## Changes

The last pull request for this problem fixed most of the problem, but it looks like the bar character in `Class.TextChannel | TextChannels` is now being used for the markdown table. 

![IncorrectMarkdown](https://github.com/Roblox/creator-docs/assets/19847497/a8ea0815-7bd3-4e92-bea5-4e6a13067a7f)

This is the reason why this pull request adds an escape character before the bar. It is unknown if this will break the automatic link:

`Class.TextChannel \| TextChannels`

I tried to see what was done in such a scenario on other pages, but I was unable to find a similar scenario. The closest I found was this table on [Datatype.Vector3](https://create.roblox.com/docs/reference/engine/datatypes/Vector3) However, it turned out that table just used pure html tags for its table and it doesn't override the default text link. 

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
