### PR TITLE
Add legacy chat service back to navigation.md

### DIFF
--- a/content/common/navigation/engine/guides.yaml
+++ b/content/common/navigation/engine/guides.yaml
@@ -406,6 +406,8 @@ navigation:
             path: /chat/bubble-chat
           - title: Migrating to In-Experience Text Chat
             path: /chat/migrate-to-in-experience-text-chat
+          - title: Legacy Chat Service
+            path: /chat/legacy/legacy-chat-system
   - title: Cloud Services
     section:
       - title: Data Stores


### PR DESCRIPTION
## Changes

Re-adds a link to Legacy Chat Service back to the navigation bar. Many games still rely on the Lua chat, so it should've never been hidden.

The article already mentions migrating to the newer chat is recommended.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
