### PR TITLE
Update Spherecast error cases in WorldRoot.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/WorldRoot.yaml
+++ b/content/en-us/reference/engine/classes/WorldRoot.yaml
@@ -897,8 +897,8 @@ methods:
       and the `Datatype.RaycastResult.Position|Position` property represents the
       intersection point that causes the hit.
 
-      This method throws an error if it is passed invalid `Datatype.CFrame`,
-      size, or direction inputs.
+      This method throws an error if it is passed invalid radius
+      or direction inputs.
     code_samples:
       - worldroot---spherecast
     parameters:


### PR DESCRIPTION
## Changes

Sphere cast documentation previously stated that:
"This method throws an error if it is passed invalid CFrame, size, or direction inputs."

However a sphere cast doesn't take in a CFrame or size value.

I've updated this to be "radius or direction".

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
