### PR TITLE
Fix a typo in a sample script in unity.md

### DIFF
--- a/content/en-us/unity.md
+++ b/content/en-us/unity.md
@@ -104,7 +104,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local performSomeAction = require(ReplicatedStorage.performSomeAction)
 
 -- Assumes that this script is a child of the fishing pole
-local fishingPole = Script.parent
+local fishingPole = script.Parent
 local ACTION_CAST = "Cast"
 
 -- Check that the key is down, then call another function


### PR DESCRIPTION
## Changes

This fixes a typo by changing `Script.parent` to `script.Parent`. 
<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
