### PR TITLE
Add Instance.Name size limit

### DIFF
--- a/content/en-us/reference/engine/classes/Instance.yaml
+++ b/content/en-us/reference/engine/classes/Instance.yaml
@@ -102,6 +102,7 @@ properties:
       necessarily unique identifiers however; multiple children of an object may
       share the same name. Names are used to keep the object hierarchy
       organized, along with allowing scripts to access specific objects.
+      The name of an instance cannot exceed 100 characters in size.
 
       The name of an object is often used to access the object through the data
       model hierarchy using the following methods:


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

Added 100 character limit information to instance.Name. Obtained information from Roblox Studio, where setting the property to longer string truncates it to 100.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
