### PR TITLE
Parity between VRService and UserInputService `RecenterUserHeadCFrame` methods

### DIFF
--- a/content/en-us/reference/engine/classes/VRService.yaml
+++ b/content/en-us/reference/engine/classes/VRService.yaml
@@ -280,7 +280,7 @@ methods:
       This function can be used to ensure that the user's in-game head is
       positioned according to the location of the user's VR headset.
 
-      This is similar to the `Class.UserInputService` function,
+      This behaves identically to the `Class.UserInputService` function,
       `Class.UserInputService:RecenterUserHeadCFrame()`.
 
       Since `VRServiceService` only runs client-side, this function will only


### PR DESCRIPTION
## Changes

The `VRService:RecenterUserHeadCFrame()` states that it is [_similar_](https://create.roblox.com/docs/reference/engine/classes/VRService#RecenterUserHeadCFrame) to `UserInputService:ReenterUserHeadCFrame()`, whereas the `UserInputService` version states that it is [_identical_](https://create.roblox.com/docs/reference/engine/classes/UserInputService#RecenterUserHeadCFrame) to the other. This is an important language distinction, as similarity does not communicate that they are identical.

This PR changes the `VRService` version language to also state that it is identical, not just similar.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
