### PR TITLE
fix: patch formatting on TextChatService.OnBubbleDisplay

### DIFF
--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -302,8 +302,8 @@ callbacks:
     returns:
       - type: Tuple
         summary: |
-          If a
-          `Class.TextChatMessagethose properties will be applied to the associated bubble, overriding `Class.BubbleChatConfiguration`
+          If a `Class.TextChatMessagethose` is returned, those properties will be
+          applied to the associated bubble, overriding `Class.BubbleChatConfiguration`
           properties.
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -302,7 +302,7 @@ callbacks:
     returns:
       - type: Tuple
         summary: |
-          If a `Class.TextChatMessagethose` is returned, those properties will be
+          If a `Class.TextChatMessage` is returned, those properties will be
           applied to the associated bubble, overriding `Class.BubbleChatConfiguration`
           properties.
     tags: []


### PR DESCRIPTION
* Add needed closing backtick on return value

## Changes
Added a backtick to the return value to allow for documentation linking and prevention against weird formatting errors like this:
![image](https://github.com/Roblox/creator-docs/assets/66774833/ca2074e1-24c5-410c-8483-126fb7a672b6)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
