### PR TITLE
fix: Change incorrect assignment of variable on line 71

### DIFF
--- a/content/en-us/tutorials/fundamentals/coding-4/glow-lights-with-for-loops.md
+++ b/content/en-us/tutorials/fundamentals/coding-4/glow-lights-with-for-loops.md
@@ -68,7 +68,7 @@ Remember, a for loop starts with keyword `for` followed by a control variable. T
    end
    ```
 
-2. In scope of the for loop, set the brightness property of the light to the value in the control variable by typing `light.Brightness = brightnessChange`. Now, when the loop runs, the light will become brighter.
+2. In scope of the for loop, set the brightness property of the light to the value in the control variable by typing `light.Brightness = currentBrightness`. Now, when the loop runs, the light will become brighter.
 
    ```lua
    for currentBrightness = 0, 5, brightnessChange do


### PR DESCRIPTION
## Changes

Replaced `Light.Brightness = brightnessChange` to `Light.Brightness = currentBrightness`, because the former is incorrect and diverges from the code written below on line 75 of the tutorial, thus possibly leading to confusion/mistake.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.