### PR TITLE
Make refresh token bullets consistent with Access token bullets

### DIFF
--- a/content/en-us/cloud/reference/oauth2.md
+++ b/content/en-us/cloud/reference/oauth2.md
@@ -96,10 +96,9 @@ endpoint.
   the refresh token to obtain a new set of tokens, which includes an access token,
   a refresh token, and an ID token. A refresh token:
 
-  - Has a lifetime of six months.
-  - Can be used to obtain a new set of tokens.
-  - Can be invalidated before it expires if an app user revokes the authorization
-    from user settings.
+  - Is valid for 6 months.
+  - Can only be used once before it expires to refresh tokens.
+  - Can be invalidated before it expires if an app user revokes the authorization.
 
 - **ID Token** - Provides proof that a user's identity has been authenticated. Its
   content depends on the scopes requested and can contain basic user information,


### PR DESCRIPTION
Following up on https://github.com/Roblox/creator-docs/pull/164

## Changes

Made refresh token bullet points consistent with Access token bullet points for easier comparison.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
