### PR TITLE
Fix broken backticks in in-line code samples

### DIFF
--- a/content/en-us/education/build-it-play-it-story-games/code-the-story.md
+++ b/content/en-us/education/build-it-play-it-story-games/code-the-story.md
@@ -57,15 +57,14 @@ Next, the first string of the story needs to be combined with the player's answe
 
 2. Still on the same line, type the name of the variable holding the player's answer.
 
-   ````lua
+   ```lua
        -- Code story between the dashes
        -- =============================================
            local name1 = storyMaker:GetInput("What is your favorite name?")
 
            local story = "In a tree on a hill lives the great wizard " .. name1
        -- =============================================
-     ```
-   ````
+   ```
 
 ## Showing the Story
 

--- a/content/en-us/reference/engine/classes/AvatarEditorService.yaml
+++ b/content/en-us/reference/engine/classes/AvatarEditorService.yaml
@@ -376,7 +376,7 @@ methods:
         summary: |
           Returns an array of item details with the following fields:
 
-          ````lua
+          ```lua
             {
               "AssetType" = "string",
               "CreatorName" = "string",
@@ -400,8 +400,7 @@ methods:
               "Price" = 0,
               "ProductId" = 0
             }
-          ```.
-          ````
+          ```
     tags:
       - Yields
     deprecation_message: ''

--- a/content/en-us/reference/engine/classes/HumanoidDescription.yaml
+++ b/content/en-us/reference/engine/classes/HumanoidDescription.yaml
@@ -1597,14 +1597,13 @@ methods:
           A dictionary of emotes where the key is the emote name and the value
           is an array of emote asset IDs. Example:
 
-          ````lua
+          ```lua
           {
               Salute = {3360689775},
               Agree = {4849487550},
               Disagree = {4849495710}
           }
-          ```.
-          ````
+          ```
     tags: []
     deprecation_message: ''
     security: None
@@ -1647,14 +1646,13 @@ methods:
           An array of tables describing the name and slot which each emote is
           equipped. Example:
 
-          ````lua
+          ```lua
           {
               {Slot = 3, Name = "Salute"},
               {Slot = 2, Name = "Agree"},
               {Slot = 1, Name = "Disagree"},
           }
-          ```.
-          ````
+          ```
     tags: []
     deprecation_message: ''
     security: None
@@ -1766,14 +1764,13 @@ methods:
           A dictionary of emotes where the key is the emote name and the value
           is an array of emote asset IDs. Example:
 
-          ````lua
+          ```lua
           {
               Salute = {3360689775},
               Agree = {4849487550},
               Disagree = {4849495710}
           }
-          ```.
-          ````
+          ```
     returns:
       - type: void
         summary: ''
@@ -1828,14 +1825,13 @@ methods:
           &ndash; OR &ndash; An array of tables describing the name and slot
           which each emote is equipped. Example:
 
-          ````lua
+          ```lua
           {
               {Slot = 3, Name = "Salute"},
               {Slot = 2, Name = "Agree"},
               {Slot = 1, Name = "Disagree"},
           }
-          ```.
-          ````
+          ```
     returns:
       - type: void
         summary: ''
@@ -1875,14 +1871,13 @@ events:
           A dictionary of emotes where the key is the emote name and the value
           is an array of emote asset IDs. Example:
 
-          ````lua
+          ```lua
           {
               Salute = {3360689775},
               Agree = {4849487550},
               Disagree = {4849495710}
           }
-          ```.
-          ````
+          ```
     tags: []
     deprecation_message: ''
     security: None
@@ -1929,14 +1924,13 @@ events:
           An array of tables describing the name and slot which each emote is
           equipped. Example:
 
-          ````lua
+          ```lua
           {
               {Slot = 3, Name = "Salute"},
               {Slot = 2, Name = "Agree"},
               {Slot = 1, Name = "Disagree"},
           }
-          ```.
-          ````
+          ```
     tags: []
     deprecation_message: ''
     security: None

--- a/content/en-us/reference/engine/classes/Tool.yaml
+++ b/content/en-us/reference/engine/classes/Tool.yaml
@@ -489,7 +489,7 @@ events:
       print "Tool deactivated" when the player releases the left mouse button,
       while the tool is equipped.
 
-      ````lua
+      ```lua
       local tool = Instance.new("Tool")
       tool.RequiresHandle = false
       tool.Parent = game.Players.LocalPlayer.Backpack
@@ -499,8 +499,7 @@ events:
       end
 
       tool.Deactivated:Connect(toolDeactivated)
-      ```"
-      ````
+      ```
     code_samples:
       - player-fly-tool
     parameters: []


### PR DESCRIPTION
## Changes
A few pages have broken backtick syntax for in-line code samples. For example, they begin and end with four ` instead of three. Additionally, before the closing backticks, there is a duplicate set of three backticks followed by a period or quote. This duplicate set leaks markdown syntax into the code sample, as shown in this screenshot at the bottom:
![image](https://github.com/Roblox/creator-docs/assets/55513323/e010c338-5c24-4899-8476-48739bec8800)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
