### PR TITLE
Fix ScrollingFrame descriptions around ScrollingFrame.AutomaticCanvasSize

### DIFF
--- a/content/en-us/reference/engine/classes/ScrollingFrame.yaml
+++ b/content/en-us/reference/engine/classes/ScrollingFrame.yaml
@@ -16,7 +16,7 @@ properties:
     summary: |
       The size in offsets of the area that is scrollable.
     description: |
-      The size in offsets of the area that is scrollable. This property is set to the maximum of the `Class.ScrollingFrame.CanvasSize` property and the size of the children if `Class.ScrollingFrame.AutomaticCanvasSize` is set to something other than None.
+      The size in offsets of the area that is scrollable. This property is set to the maximum of the `Class.ScrollingFrame.CanvasSize` property and the size of the children if `Class.ScrollingFrame.AutomaticCanvasSize` is set to something other than `None|Enum.AutomaticSize`.
     code_samples:
     type: Vector2
     tags:
@@ -61,7 +61,7 @@ properties:
       size will adjust to fit that content.
 
       When AutomaticCanvasSize is set to an
-      `Enum.AutomaticSize|Enum.AutomaticSize` value other than None,
+      `Enum.AutomaticSize` value other than `None|no-link`,
       `Class.ScrollingFrame.AbsoluteCanvasSize` may resize depending on its
       child content.
     code_samples:

--- a/content/en-us/reference/engine/classes/ScrollingFrame.yaml
+++ b/content/en-us/reference/engine/classes/ScrollingFrame.yaml
@@ -16,7 +16,11 @@ properties:
     summary: |
       The size in offsets of the area that is scrollable.
     description: |
-      The size in offsets of the area that is scrollable. This property is set to the maximum of the `Class.ScrollingFrame.CanvasSize` property and the size of the children if `Class.ScrollingFrame.AutomaticCanvasSize` is set to something other than `None|Enum.AutomaticSize`.
+      The size in offsets of the area that is scrollable. By default, this property is
+      set to the maximum of the `Class.ScrollingFrame.CanvasSize|CanvasSize`
+      property and the size of the children if
+      `Class.ScrollingFrame.AutomaticCanvasSize|AutomaticCanvasSize` is set
+      to something other than `Enum.AutomaticSize.None`.
     code_samples:
     type: Vector2
     tags:
@@ -60,10 +64,10 @@ properties:
       add text and other content to a UI object at edit or run time, and the
       size will adjust to fit that content.
 
-      When AutomaticCanvasSize is set to an
-      `Enum.AutomaticSize` value other than `None|no-link`,
-      `Class.ScrollingFrame.AbsoluteCanvasSize` may resize depending on its
-      child content.
+      When this property is set to an
+      `Enum.AutomaticSize` value other than `Enum.AutomaticSize|None`,
+      `Class.ScrollingFrame.AbsoluteCanvasSize|AbsoluteCanvasSize` may
+      resize depending on its child content.
     code_samples:
     type: AutomaticSize
     tags: []

--- a/content/en-us/reference/engine/classes/ScrollingFrame.yaml
+++ b/content/en-us/reference/engine/classes/ScrollingFrame.yaml
@@ -16,7 +16,7 @@ properties:
     summary: |
       The size in offsets of the area that is scrollable.
     description: |
-      The size in offsets of the area that is scrollable. By default, this property is
+      The size in offsets of the area that is scrollable. This property is
       set to the maximum of the `Class.ScrollingFrame.CanvasSize|CanvasSize`
       property and the size of the children if
       `Class.ScrollingFrame.AutomaticCanvasSize|AutomaticCanvasSize` is set

--- a/content/en-us/reference/engine/classes/ScrollingFrame.yaml
+++ b/content/en-us/reference/engine/classes/ScrollingFrame.yaml
@@ -16,7 +16,7 @@ properties:
     summary: |
       The size in offsets of the area that is scrollable.
     description: |
-      The size in offsets of the area that is scrollable.
+      The size in offsets of the area that is scrollable. This property is set to the maximum of the `Class.ScrollingFrame.CanvasSize` property and the size of the children if `Class.ScrollingFrame.AutomaticCanvasSize` is set to something other than None.
     code_samples:
     type: Vector2
     tags:
@@ -61,9 +61,9 @@ properties:
       size will adjust to fit that content.
 
       When AutomaticCanvasSize is set to an
-      `Enum.AutomaticSize|Enum.AutomaticSize` value to anything other than None,
-      `Class.ScrollingFrame.CanvasSize` may resize depending on its child
-      content.
+      `Enum.AutomaticSize|Enum.AutomaticSize` value other than None,
+      `Class.ScrollingFrame.AbsoluteCanvasSize` may resize depending on its
+      child content.
     code_samples:
     type: AutomaticSize
     tags: []


### PR DESCRIPTION
## Changes

This PR updates the descriptions for the ScrollingFrame.AutomaticCanvasSize and ScrollingFrame.AbsoluteCanvasSize property to be more descriptive. The prior descriptions were definitely causing confusion as evidenced by several dev forum threads and me personally running into the issue as well.

Please see comments in https://roblox.atlassian.net/browse/UISYS-1976 

## Checks

By submitting your pull request for review, you agree to the following:

- [x ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x ] To the best of my knowledge, all proposed changes are accurate.
