### PR TITLE
Fix typo in userdata data type

### DIFF
--- a/content/en-us/luau/userdata.md
+++ b/content/en-us/luau/userdata.md
@@ -3,4 +3,4 @@ title: Userdata
 description: Arbitrary C/C++ data that exists in Luau.
 ---
 
-Userdata is one of the basic types in Lua. Userdata represents arbitrary C/C++ data that exist in Luau. See [Userdata](https://www.lua.org/pil/28.1.html) for more information.
+Userdata is one of the basic types in Lua. Userdata represents arbitrary C/C++ data that exists in Luau. See [Userdata](https://www.lua.org/pil/28.1.html) for more information.


### PR DESCRIPTION
Arbitrary C/C++ data that exist<ins>s</ins> in Luau.

the page description got it right, the page content didn't

## Changes

- fix typo on the [userdata](https://create.roblox.com/docs/luau/userdata) page

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
