### PR TITLE
fix typo in "deprecated"

### DIFF
--- a/content/en-us/reference/engine/classes/Status.yaml
+++ b/content/en-us/reference/engine/classes/Status.yaml
@@ -15,7 +15,7 @@ tags:
   - Deprecated
 deprecation_message: |
   Status is an unfinished object designed to store custom `Class.Humanoid`
-  statuses. It has been depreciated and should not be used by developers in new
+  statuses. It has been deprecated and should not be used by developers in new
   work.
 
   Developers looking to implement custom `Class.Humanoid` statuses should use


### PR DESCRIPTION
## Changes
Fixes a small typo where it says "depreciated" instead of "deprecated"

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
