### PR TITLE
Update selling-on-the-creator-store.md Seller Onboarding Links

### DIFF
--- a/content/en-us/production/publishing/selling-on-the-creator-store.md
+++ b/content/en-us/production/publishing/selling-on-the-creator-store.md
@@ -86,7 +86,7 @@ Once Stripe accepts your application, you cannot change the country associated w
 
 ### Checking Approval Status
 
-To check the status of your application, revisit the [Seller Onboarding](https://create.roblox.com/settings/eligibility/seller-onboarding) page, then click **Edit Account Info**. Your approval status can be in any of the following states:
+To check the status of your application, revisit the [Seller Onboarding](https://create.roblox.com/settings/eligibility/priced-assets) page, then click **Edit Account Info**. Your approval status can be in any of the following states:
 
 - **Pending** — Your information is being reviewed.
 - **Failed** — Your seller account has not been created, either because of an error or because your information was incorrect.
@@ -118,7 +118,7 @@ Your earnings automatically pay out once a month to the bank associated with you
 
 <Alert severity="warning">
 
-If your seller eligibility is suspended, either due to a change of seller information or moderation consequences, payouts are frozen until you can restore your eligibility. To see the status of your account, see the [Seller Onboarding](https://create.roblox.com/settings/eligibility/seller-onboarding) page.
+If your seller eligibility is suspended, either due to a change of seller information or moderation consequences, payouts are frozen until you can restore your eligibility. To see the status of your account, see the [Seller Onboarding](https://create.roblox.com/settings/eligibility/priced-assets) page.
 
 </Alert>
 


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
The links should point to:
https://create.roblox.com/settings/eligibility/priced-assets to check seller onboarding status
Currently, the link that is set will 404, as it does not exist.


## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
