### PR TITLE
Update PluginGui.yaml to reflect new behaviour

### DIFF
--- a/content/en-us/reference/engine/classes/PluginGui.yaml
+++ b/content/en-us/reference/engine/classes/PluginGui.yaml
@@ -40,57 +40,10 @@ methods:
       Binds a function to the `Class.PluginGui` close button, overriding the
       default behavior.
     description: |
-      This function binds a function to the `Class.PluginGui` close button,
-      overriding the default behavior.
+      This function binds a callback to the `Class.PluginGui` close button.
 
-      By default, when the user clicks the 'x' button in the top right corner of
-      the `Class.PluginGui` the `Class.LayerCollector.Enabled|Enabled` property
-      is set to _false_, closing the window. When a custom function is bound
-      using BindToClose this behavior is overwritten, allowing you to check if
-      the user really wants to close the window or give them an opportunity to
-      save their work.
-
-      As the default closing behavior is overwritten by this function, you'll
-      need to configure the `Class.PluginGui` to close manually by setting
-      `Class.LayerCollector.Enabled|PluginGui.Enabled` to _false_. For example,
-      in the below snippet users are required to click a confirm button to close
-      the GUI:
-
-      ```lua
-      local closing = false
-      pluginGui:BindToClose(function()
-      	-- make sure we haven't already made a button
-      	if closing then
-      		return
-      	end
-      	closing = true
-
-      	-- create confirm button
-      	local confirmButton = Instance.new("TextButton")
-      	confirmButton.AnchorPoint = Vector2.new(0.5, 0.5)
-      	confirmButton.Size = UDim2.new(0.5, 0, 0.5, 0)
-      	confirmButton.Position = UDim2.new(0.5, 0, 0.5, 0)
-      	confirmButton.BackgroundColor3 = Color3.new(1, 0, 0)
-      	confirmButton.Text = "Close?"
-      	confirmButton.Parent = pluginGui
-
-      	-- listen for click
-      	confirmButton.Activated:Connect(function()
-      		-- close the gui
-      		pluginGui.Enabled = false
-
-      		-- remove confirm button
-      		confirmButton:Destroy()
-      	end)
-      end)
-      ```
-
-      You can call BindToClose with no argument to 'unbind' and revert to the
-      default behavior described above. For example:
-
-      ```lua
-      pluginGui:BindToClose()
-      ```
+      The `Class.PluginGui` will be closed after the callback completes. The
+      callback cannot yield.
 
       See also:
 

--- a/content/en-us/reference/engine/classes/PluginGui.yaml
+++ b/content/en-us/reference/engine/classes/PluginGui.yaml
@@ -37,8 +37,7 @@ properties:
 methods:
   - name: PluginGui:BindToClose
     summary: |
-      Binds a function to the `Class.PluginGui` close button, overriding the
-      default behavior.
+      Binds a callback to the `Class.PluginGui` close button.
     description: |
       This function binds a callback to the `Class.PluginGui` close button.
 


### PR DESCRIPTION
## Changes

PluginGuis are now closed regardless of the existence of this callback, basically making the majority of this documentation, including the code sample, wrong.

[See bug report response here](https://devforum.roblox.com/t/the-plugingui-bindtoclose-method-does-not-override-the-default-closing-behavior/2741947/4)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
