### PR TITLE
Changed mouse.Hit.p to mouse.Hit.Position

### DIFF
--- a/content/en-us/reference/engine/classes/Mouse.yaml
+++ b/content/en-us/reference/engine/classes/Mouse.yaml
@@ -71,7 +71,7 @@ properties:
       Developers can get obtain the position of Hit like so:
 
       ```
-      local position = mouse.Hit.p
+      local position = mouse.Hit.Position
       ```
 
       Hit is often used by `Class.Tool|Tools` to fire a weapon towards the mouse


### PR DESCRIPTION
## Changes

In the Mouse class documentation I changed the piece of code `mouse.Hit.p` to `mouse.Hit.Position` since CFrame.p is less understandable than `mouse.Hit.Position`

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
