### PR TITLE
FindClosestPointOnSurface has an incorrect return types and summary

### DIFF
--- a/content/en-us/reference/engine/classes/EditableMesh.yaml
+++ b/content/en-us/reference/engine/classes/EditableMesh.yaml
@@ -125,10 +125,9 @@ methods:
         summary: |
           Point position in the mesh's local object space.
     returns:
-      - type: Tuple
+      - type: number
         summary: |
-          Tuple of the triangle ID, point on the mesh in local object space, and
-          the barycentric coordinate of the position within the triangle.
+          Closest stable triangle ID
     tags: []
     deprecation_message: ''
     security: None

--- a/content/en-us/reference/engine/classes/EditableMesh.yaml
+++ b/content/en-us/reference/engine/classes/EditableMesh.yaml
@@ -125,7 +125,7 @@ methods:
         summary: |
           Point position in the mesh's local object space.
     returns:
-      - type: number
+      - type: tuple
         summary: |
           Closest stable triangle ID
     tags: []

--- a/content/en-us/reference/engine/classes/EditableMesh.yaml
+++ b/content/en-us/reference/engine/classes/EditableMesh.yaml
@@ -125,7 +125,7 @@ methods:
         summary: |
           Point position in the mesh's local object space.
     returns:
-      - type: tuple
+      - type: Tuple
         summary: |
           Closest stable triangle ID
     tags: []


### PR DESCRIPTION
> ## Changes
> 
> Minor misinformation fix of the FindClosestPointOnSurface method having wrong return values
> 
> 
> ## Checks
> 
> By submitting your pull request for review, you agree to the following:
> 
>     * [x]  This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
> 
>     * [x]  I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
> 
>     * [x]  To the best of my knowledge, all proposed changes are accurate.

