### PR TITLE
Replace legacy approximate Luau conditional operator

### DIFF
--- a/content/en-us/luau/luau-csharp-comparison.md
+++ b/content/en-us/luau/luau-csharp-comparison.md
@@ -428,10 +428,8 @@ else {
 
 ### Conditional Operator
 
-Luau doesn't offer a direct equivalent to the C# conditional operator, `a ? b : c`. However, the Luau idiom `a and b or c` offers a close approximation, provided `b` isn't `false` or `nil`.
-
-```lua title='Approximate of the conditional operator in Luau'
-local max = x > y and x or y
+```lua title='Conditional operator in Luau'
+local max = if x > y then x else y
 ```
 
 ```cs title='Conditional operator in C#'

--- a/content/en-us/luau/luau-csharp-comparison.md
+++ b/content/en-us/luau/luau-csharp-comparison.md
@@ -162,7 +162,7 @@ To learn more about tables in Luau, see [Tables](./tables.md).
 
 You can use tables in Luau as dictionaries just like in C#.
 
-```lua title='Dictionary tables in Luau'
+```lua title='Dictionary Tables in Luau'
 local dictionary = {
 	val1 = "this",
 	val2 = "is"
@@ -175,7 +175,7 @@ dictionary.val1 = nil  -- Removes 'val1' from table
 dictionary["val3"] = "a dictionary"  -- Overwrites 'val3' or sets new key-value pair
 ```
 
-```cs title='Dictionary tables in C#'
+```cs title='Dictionary Tables in C#'
 Dictionary dictionary = new Dictionary()
 {
 	{ "val1", "this" },
@@ -193,7 +193,7 @@ dictionary.Add("val3", "a dictionary");  // Creates a new key-value pair
 
 You can use tables in Luau as arrays just like in C#. Indices start at `1` in Luau and `0` in C#.
 
-```lua title='Numerically-indexed tables in Luau'
+```lua title='Numerically-Indexed Tables in Luau'
 local npcAttributes = {"strong", "intelligent"}
 
 print(npcAttributes[1])  -- Outputs 'strong'
@@ -211,7 +211,7 @@ table.insert(npcAttributes, 1, "brave")
 table.remove(npcAttributes, 3)
 ```
 
-```cs title='Numerically-indexed tables in C#'
+```cs title='Numerically-Indexed Tables in C#'
 List npcAttributes = new List{"strong", "intelligent"};
 
 Console.WriteLine(npcAttributes[0]);  // Outputs 'strong'
@@ -428,11 +428,11 @@ else {
 
 ### Conditional Operator
 
-```lua title='Conditional operator in Luau'
+```lua title='Conditional Operator in Luau'
 local max = if x > y then x else y
 ```
 
-```cs title='Conditional operator in C#'
+```cs title='Conditional Operator in C#'
 int max = (x > y) ? x : y;
 ```
 
@@ -442,7 +442,7 @@ To learn more about loops in Luau, see [Control Structures](./control-structures
 
 ### While and Repeat Loops
 
-```lua title='While and Repeat loops in Luau'
+```lua title='While and Repeat Loops in Luau'
 while boolExpression do
 	doSomething()
 end
@@ -452,7 +452,7 @@ repeat
 until not boolExpression
 ```
 
-```cs title='While and Repeat loops in C#'
+```cs title='While and Repeat Loops in C#'
 while (boolExpression) {
 	doSomething();
 }
@@ -464,7 +464,7 @@ do {
 
 ### For Loops
 
-```lua title='Generic For loops in Luau'
+```lua title='Generic For Loops in Luau'
 -- Forward loop
 for i = 1, 10 do
 	doSomething()
@@ -476,7 +476,7 @@ for i = 10, 1, -1 do
 end
 ```
 
-```cs title='Generic For loops in C#'
+```cs title='Generic For Loops in C#'
 // Forward loop
 for (int i = 1; i <= 10; i++) {
 	doSomething();
@@ -488,7 +488,7 @@ for (int i = 10; i >= 1; i--) {
 }
 ```
 
-```lua title='For loops over tables in Luau'
+```lua title='For Loops Over Tables in Luau'
 local abcList = {"a", "b", "c"}
 
 for i, v in ipairs(abcList) do
@@ -502,7 +502,7 @@ for k, v in pairs(abcDictionary) do
 end
 ```
 
-```cs title='For loops over lists in C#'
+```cs title='For Loops Over Lists in C#'
 List<string> abcList = new List<string>{"a", "b", "c"};
 
 foreach (string v in abcList) {
@@ -526,14 +526,14 @@ To learn more about functions in Luau, see [Functions](./functions.md).
 
 ### Generic Functions
 
-```lua title='Generic functions in Luau'
+```lua title='Generic Functions in Luau'
 -- Generic function
 local function increment(number)
 	return number + 1
 end
 ```
 
-```cs title='Generic functions in C#'
+```cs title='Generic Functions in C#'
 // Generic function
 int increment(int number) {
 	return number + 1;


### PR DESCRIPTION
## Changes

- Replaces the legacy approximate Luau conditional operators following the `a and b or c` syntax, with modern if-then-else expresions following the `if a then b or c` syntax.

- This change is supported by the Luau syntax docs stating that if-then-else expressions are now preferred over the standard Lua idiom of using the `a and b or c` syntax - https://luau-lang.org/syntax#if-then-else-expressions

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.