### PR TITLE
Enum.Materials summary updated what classes they work on.

### DIFF
--- a/content/en-us/reference/engine/enums/Material.yaml
+++ b/content/en-us/reference/engine/enums/Material.yaml
@@ -44,7 +44,7 @@ items:
     deprecation_message: ''
   - name: Basalt
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 788
     tags: []
     deprecation_message: ''
@@ -56,7 +56,7 @@ items:
     deprecation_message: ''
   - name: CrackedLava
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 804
     tags: []
     deprecation_message: ''
@@ -68,7 +68,7 @@ items:
     deprecation_message: ''
   - name: Limestone
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 820
     tags: []
     deprecation_message: ''
@@ -80,7 +80,7 @@ items:
     deprecation_message: ''
   - name: Pavement
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 836
     tags: []
     deprecation_message: ''
@@ -104,19 +104,19 @@ items:
     deprecation_message: ''
   - name: Rock
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 896
     tags: []
     deprecation_message: ''
   - name: Sandstone
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 912
     tags: []
     deprecation_message: ''
   - name: CorrodedMetal
     summary: |
-      Applies to `Class.BasePart` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1040
     tags: []
     deprecation_message: ''
@@ -146,7 +146,7 @@ items:
     deprecation_message: ''
   - name: LeafyGrass
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1284
     tags: []
     deprecation_message: ''
@@ -164,31 +164,31 @@ items:
     deprecation_message: ''
   - name: Snow
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1328
     tags: []
     deprecation_message: ''
   - name: Mud
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1344
     tags: []
     deprecation_message: ''
   - name: Ground
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1360
     tags: []
     deprecation_message: ''
   - name: Asphalt
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1376
     tags: []
     deprecation_message: ''
   - name: Salt
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1392
     tags: []
     deprecation_message: ''
@@ -200,7 +200,7 @@ items:
     deprecation_message: ''
   - name: Glacier
     summary: |
-      Applies to `Class.Terrain` only.
+      Applies to `Class.BasePart` and `Class.Terrain`.
     value: 1552
     tags: []
     deprecation_message: ''


### PR DESCRIPTION
Updated multiple materials summary's regarding if they work on 'BasePart' and 'Terrain', as most of them now work on 'BasePart' as-well.

## Changes
Changed summary on multiple materials that were previously marked as "Applies to 'Class.Terrain' only." to "Applies to 'Class.BasePart' and 'Class.Terrain'." as these materials now work on both.

![Screenshot 2024-05-06 005112](https://github.com/Roblox/creator-docs/assets/90548046/c4bb83e4-a1b7-485f-b5e4-2fbeb77e51ee)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
