### PR TITLE
added-missing-parenthesis

### DIFF
--- a/content/en-us/cloud-services/experience-notifications.md
+++ b/content/en-us/cloud-services/experience-notifications.md
@@ -176,7 +176,7 @@ local canPrompt = canPromptOptIn()
 if canPrompt then
 	local success, errorMessage = pcall(function()
 		ExperienceNotificationService:PromptOptIn()
-	end
+	end)
 end
 
 -- Listen to opt-in prompt closed event 


### PR DESCRIPTION
## Changes

Just a tiny code sample fix: added a missing parenthesis in the Roblox docs "Notification Permission Prompt Implementation" code sample.

The current Roblox docs code sample when copied directly would throw the following error, which is fixed by adding a parenthesis:
<img width="607" alt="Screenshot 2024-05-09 at 8 48 27 AM" src="https://github.com/Roblox/creator-docs/assets/88632829/d66f394c-df9e-42d8-adc0-40f58b1d90b9"> 

Roblox docs sample link containing the issue:
https://create.roblox.com/docs/cloud-services/experience-notifications#prompting-users-to-enable-notifications

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
