### PR TITLE
Update Players.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/Players.yaml
+++ b/content/en-us/reference/engine/classes/Players.yaml
@@ -113,12 +113,6 @@ properties:
       client. For the server, on which `Class.Script` objects run their code,
       this property is `nil`.
 
-      #### Loading GUIs
-
-      When creating loading GUIs using `Class.ReplicatedFirst`, sometimes a
-      `Class.LocalScript` can run before the LocalPlayer is available. In this
-      case, you should yield until it becomes available by using
-      `Class.Instance:GetPropertyChangedSignal()`
     code_samples:
     type: Player
     tags:

--- a/content/en-us/reference/engine/classes/Players.yaml
+++ b/content/en-us/reference/engine/classes/Players.yaml
@@ -112,7 +112,6 @@ properties:
       `Class.ModuleScript|ModuleScripts` required by them, since they run on the
       client. For the server, on which `Class.Script` objects run their code,
       this property is `nil`.
-
     code_samples:
     type: Player
     tags:


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
localplayer will always be non nil when localscripts run, even if in replicated first (this change was made 8 years ago why is the documentation so outdated)

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
https://devforum.roblox.com/t/localplayer-timing-update/92351/11

## Checks

By submitting your pull request for review, you agree to the following:

- [ x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x ] To the best of my knowledge, all proposed changes are accurate.
