### PR TITLE
Update HttpService.yaml to include info about concurrent request limit

### DIFF
--- a/content/en-us/reference/engine/classes/HttpService.yaml
+++ b/content/en-us/reference/engine/classes/HttpService.yaml
@@ -64,6 +64,7 @@ description: |
   - For each Roblox game server, there is a limit of 500 HTTP requests per
     minute. Exceeding this may cause request-sending functions to stall entirely
     for about 30 seconds.
+  - Each Roblox game server can handle only 3 concurrent HTTP requests. Any additional requests will yield until one of the ongoing requests completes.
   - Requests cannot be made to any Roblox website, such as www.roblox.com.
   - Web requests can fail for many reasons, so it is important to "code
     defensively" (use `pcall`) and have a plan for when requests fail.


### PR DESCRIPTION
Updates HttpService docs to include info about the maximum of 3 concurrent requests:

https://devforum.roblox.com/t/httpservice-requests-yields-forever-even-when-server-sends-data-back/2955426/8?u=bvetterdays

## Changes

Updates HttpService docs to include info about the maximum of 3 concurrent requests:

https://devforum.roblox.com/t/httpservice-requests-yields-forever-even-when-server-sends-data-back/2955426/8?u=bvetterdays

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.