### PR TITLE
Fix description of ScriptContext to remove outdated information

### DIFF
--- a/content/en-us/reference/engine/classes/ScriptContext.yaml
+++ b/content/en-us/reference/engine/classes/ScriptContext.yaml
@@ -5,9 +5,7 @@ memory_category: Instances
 summary: ''
 description: |
   This service controls all `Class.BaseScript` objects. Most of the properties
-  and methods of this service are locked for internal use, however you may use
-  the `Class.ScriptContext.ScriptsDisabled` property to disable all scripts from
-  a thread with normal security access.
+  and methods of this service are locked for internal use.
 code_samples:
 inherits:
   - Instance


### PR DESCRIPTION
## Changes

Removes a line in the ScriptContext documentation, which implies that the ScriptContext.ScriptsDisabled is accessible without any script security level. This property was changed in 2012 to require LocalUserSecurity security, and the API member was since hidden from the reference page entirely. Hence, this most likely isn't relevant to display anymore.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
