### PR TITLE
Use task.defer instead of task.wait

### DIFF
--- a/content/en-us/projects/performance-optimization/memory.md
+++ b/content/en-us/projects/performance-optimization/memory.md
@@ -156,14 +156,12 @@ To clean up all used values for preventing memory leaks:
    ```lua title="Example"
    Players.PlayerAdded:Connect(function(player)
      player.CharacterRemoving:Connect(function(character)
-         task.wait()
-         character:Destroy()
+         task.defer(character.Destroy, character)
      end)
    end)
 
    Players.PlayerRemoving:Connect(function(player)
-	   task.wait()      
-	   player:Destroy()
+	   task.defer(player.Destroy, player)
    end)
    ```
 


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
Used task.defer to defer until the next resumption cycle, instead of task.wait.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
