### PR TITLE
Fix spacing on "Intro to Dictionaries" page

### DIFF
--- a/content/en-us/tutorials/fundamentals/coding-5/intro-to-dictionaries.md
+++ b/content/en-us/tutorials/fundamentals/coding-5/intro-to-dictionaries.md
@@ -53,36 +53,36 @@ One everyday use of dictionaries is organizing player or character information. 
 
 1. In a new script, create a dictionary named `enemy`.
 
-```lua
-local enemy = {
+	```lua
+	local enemy = {
 
-}
-```
+	}
+	```
 
 2. The first key in the dictionary will track the enemy's name with a variable called `name`.
 
-```lua
-local enemy = {
-	Name
-}
-```
+	```lua
+	local enemy = {
+		Name
+	}
+	```
 
 3. Assign an enemy name to the key, followed by a comma.
 
-```lua
-local enemy = {
-	name = "Spike",
-}
-```
+	```lua
+	local enemy = {
+		name = "Spike",
+	}
+	```
 
 4. Add a second key-value pair for how much health the enemy should have. Remember, keys should always use the same data type, but values don't have to.
 
-```lua
-local enemy = {
-	Name = "Spike",
-	Health = 1000,
-}
-```
+	```lua
+	local enemy = {
+		Name = "Spike",
+		Health = 1000,
+	}
+	```
 
 ### Using Dictionary Values
 
@@ -108,16 +108,16 @@ Changing a key's value is the same as any other variable; use the equal `=` oper
 
 1. Beneath the `enemy` table, set the enemy's name to something else.
 
-```lua
-local enemy = {
-	Name = "Spike",
-	Health = 1000,
-}
+	```lua
+	local enemy = {
+		Name = "Spike",
+		Health = 1000,
+	}
 
-enemy.Name = "Rana"
+	enemy.Name = "Rana"
 
-print("The enemy's name is " .. enemy.Name)
-```
+	print("The enemy's name is " .. enemy.Name)
+	```
 
 2. Playtest and check the Output window.
 
@@ -127,46 +127,46 @@ Dictionaries can interact with pre-existing variables declared in other parts of
 
 1. In **ServerScriptService**, create a new script named PlayerPoints. In the script, get the Players Service and create an empty dictionary named `playerPoints`.
 
-```lua
-Players = game:GetService("Players")
+	```lua
+	Players = game:GetService("Players")
 
-local playerPoints = {
+	local playerPoints = {
 
-}
-```
+	}
+	```
 
 2. Code a local function for setting player points with a parameter for a new player variable. Connect the function to the `Class.Players.PlayerAdded` event.
 
-```lua
-local playerPoints = {
+	```lua
+	local playerPoints = {
 
-}
+	}
 
-local function setPoints(newPlayer)
+	local function setPoints(newPlayer)
 
-end
+	end
 
-Players.PlayerAdded:Connect(setPoints)
-```
+	Players.PlayerAdded:Connect(setPoints)
+	```
 
 3. In the function, add a variable to get the player's `Name`, a property in every **Player** object, and a print statement for testing.
 
-```lua
-local function setPoints(newPlayer)
-	local name = newPlayer.Name
-	print("hello " .. name)
-end
-```
+	```lua
+	local function setPoints(newPlayer)
+		local name = newPlayer.Name
+		print("hello " .. name)
+	end
+	```
 
 4. Insert name into the `playerPoints` dictionary as a key, and set the value, the player's points, to 0.
 
-```lua
-local function setPoints(newPlayer)
-	local name = newPlayer.Name
-	print("hello " .. name)
-	playerPoints[name] = 0
-end
-```
+	```lua
+	local function setPoints(newPlayer)
+		local name = newPlayer.Name
+		print("hello " .. name)
+		playerPoints[name] = 0
+	end
+	```
 
 <Alert severity="warning">
 Since `name` was created as a variable, it can be accessed with the actual variable name. If `name` had been simply a key name, it would need to be accessed the same as other strings, playerPoints["name"]
@@ -174,33 +174,33 @@ Since `name` was created as a variable, it can be accessed with the actual varia
 
 5. Use `name` to print the name of the player and playerPoints[name] to print the value of the key matching the variable.
 
-```lua
-local function setPoints(newPlayer)
-	local name = newPlayer.Name
-	print("hello " .. name)
-	playerPoints[name] = 0
-	print(name .. " has " .. playerPoints[name] .. " points.")
-end
-```
+	```lua
+	local function setPoints(newPlayer)
+		local name = newPlayer.Name
+		print("hello " .. name)
+		playerPoints[name] = 0
+		print(name .. " has " .. playerPoints[name] .. " points.")
+	end
+	```
 
 6. Run the project and look into the output editor.
 
-```lua title="Finished script"
-local Players = game:GetService("Players")
+	```lua title="Finished script"
+	local Players = game:GetService("Players")
 
-local playerPoints = {
+	local playerPoints = {
 
-}
+	}
 
-local function setPoints(newPlayer)
-	local name = newPlayer.Name
-	print("hello " .. name)
-	playerPoints[name] = 0
-	print(name .. " has " .. playerPoints[name] .. " points.")
-end
+	local function setPoints(newPlayer)
+		local name = newPlayer.Name
+		print("hello " .. name)
+		playerPoints[name] = 0
+		print(name .. " has " .. playerPoints[name] .. " points.")
+	end
 
-Players.PlayerAdded:Connect(setPoints)
-```
+	Players.PlayerAdded:Connect(setPoints)
+	```
 
 ### Optional Challenges
 

--- a/content/en-us/tutorials/fundamentals/coding-5/intro-to-dictionaries.md
+++ b/content/en-us/tutorials/fundamentals/coding-5/intro-to-dictionaries.md
@@ -10,10 +10,10 @@ Dictionaries are tables that associate names or "\*keys\*\*" with a value instea
 Example:
 
 ```lua title="Lua dictionary syntax"
- local pet = {
-    Name = "Bobbie",
-    Type = "Dog",
- }
+local pet = {
+	Name = "Bobbie",
+	Type = "Dog",
+}
 ```
 
 Use dictionaries when you need to label values, not just list them in order as an array does —practice using dictionaries in this tutorial by manipulating values associated with a player.
@@ -23,24 +23,24 @@ Use dictionaries when you need to label values, not just list them in order as a
 Like arrays, dictionaries are assigned to a variable with curly brackets`{}`. **Key value pairs** are stored on separate lines followed by a comma. Keys and values can be any data type, including strings, numbers, and variable names.
 
 ```lua
- local playerNames = {
-    player1 = "Zap",
-    player2 = "Kel",
- }
- print(playerNames["player1"])
+local playerNames = {
+	player1 = "Zap",
+	player2 = "Kel",
+}
+print(playerNames["player1"])
 ```
 
 To reference parts or other instanced objects as keys, use brackets.
 
 ```lua
- local greenPart = workspace.GreenPart
- local redPart = workspace.RedPart
+local greenPart = workspace.GreenPart
+local redPart = workspace.RedPart
 
- local partList = {
-    [greenPart] = true,
-    [redPart] = false,
- }
- print(partList[redPart])
+local partList = {
+	[greenPart] = true,
+	[redPart] = false,
+}
+print(partList[redPart])
 ```
 
  <Alert severity="warning">
@@ -53,36 +53,36 @@ One everyday use of dictionaries is organizing player or character information. 
 
 1. In a new script, create a dictionary named `enemy`.
 
-   ```lua
-    local enemy = {
+```lua
+local enemy = {
 
-    }
-   ```
+}
+```
 
 2. The first key in the dictionary will track the enemy's name with a variable called `name`.
 
-   ```lua
-    local enemy = {
-       Name
-    }
-   ```
+```lua
+local enemy = {
+	Name
+}
+```
 
 3. Assign an enemy name to the key, followed by a comma.
 
-   ```lua
-    local enemy = {
-      name = "Spike",
-    }
-   ```
+```lua
+local enemy = {
+	name = "Spike",
+}
+```
 
 4. Add a second key-value pair for how much health the enemy should have. Remember, keys should always use the same data type, but values don't have to.
 
-   ```lua
-    local enemy = {
-       Name = "Spike",
-       Health  = 1000,
-    }
-   ```
+```lua
+local enemy = {
+	Name = "Spike",
+	Health = 1000,
+}
+```
 
 ### Using Dictionary Values
 
@@ -92,12 +92,12 @@ There are two ways to access dictionary values:
 
 ```lua
 local enemy = {
-   Name = "Spike",
-   Health  = 1000,
+	Name = "Spike",
+	Health = 1000,
 }
 
-print ("The villain "  ..  enemy["Name"]  ..  " approaches!")
-print ("The villain "  ..  enemy.Name  ..  " approaches!")
+print("The villain " .. enemy["Name"] .. " approaches!")
+print("The villain " .. enemy.Name .. " approaches!")
 ```
 
 Which style to use usually depends on the purpose of the table. For tables holding a collection of values like a list of players in a server, coders will usually use tableName["keyName"]. For a dictionary used to describe an object, coders are more likely to use tableName.keyName.
@@ -108,16 +108,16 @@ Changing a key's value is the same as any other variable; use the equal `=` oper
 
 1. Beneath the `enemy` table, set the enemy's name to something else.
 
-   ```lua
-      local enemy = {
-      Name = "Spike",
-      Health = 1000,
-      }
+```lua
+local enemy = {
+	Name = "Spike",
+	Health = 1000,
+}
 
-      enemy.Name = "Rana"
+enemy.Name = "Rana"
 
-      print ("The enemy's name is "  ..  enemy.Name)
-   ```
+print("The enemy's name is " .. enemy.Name)
+```
 
 2. Playtest and check the Output window.
 
@@ -127,80 +127,79 @@ Dictionaries can interact with pre-existing variables declared in other parts of
 
 1. In **ServerScriptService**, create a new script named PlayerPoints. In the script, get the Players Service and create an empty dictionary named `playerPoints`.
 
-   ```lua
-      Players = game:GetService("Players")
+```lua
+Players = game:GetService("Players")
 
-      local playerPoints = {
+local playerPoints = {
 
-      }
-   ```
+}
+```
 
 2. Code a local function for setting player points with a parameter for a new player variable. Connect the function to the `Class.Players.PlayerAdded` event.
 
-   ```lua
-      local playerPoints = {
+```lua
+local playerPoints = {
 
-      }
+}
 
-      local function setPoints(newPlayer)
+local function setPoints(newPlayer)
 
-      end
+end
 
-      Players.PlayerAdded:Connect(setPoints)
-   ```
+Players.PlayerAdded:Connect(setPoints)
+```
 
 3. In the function, add a variable to get the player's `Name`, a property in every **Player** object, and a print statement for testing.
 
-   ```lua
-      local function setPoints(newPlayer)
-         local name = newPlayer.Name
-         print("hello " .. name)
-      end
-   ```
+```lua
+local function setPoints(newPlayer)
+	local name = newPlayer.Name
+	print("hello " .. name)
+end
+```
 
 4. Insert name into the `playerPoints` dictionary as a key, and set the value, the player's points, to 0.
 
-   ```lua
-      local function setPoints(newPlayer)
-         local name = newPlayer.Name
-         print("hello " .. name)
-         playerPoints[name] = 0
-      end
-   ```
+```lua
+local function setPoints(newPlayer)
+	local name = newPlayer.Name
+	print("hello " .. name)
+	playerPoints[name] = 0
+end
+```
 
-    <Alert severity="warning">
-     Since `name` was created as a variable, it can be accessed with the actual variable name. If `name` had been simply a key name, it would need to be accessed the same as other strings, playerPoints["name"]
-
-    </Alert>
+<Alert severity="warning">
+Since `name` was created as a variable, it can be accessed with the actual variable name. If `name` had been simply a key name, it would need to be accessed the same as other strings, playerPoints["name"]
+</Alert>
 
 5. Use `name` to print the name of the player and playerPoints[name] to print the value of the key matching the variable.
 
-   ```lua
-      local function setPoints(newPlayer)
-      local name = newPlayer.Name
-      print("hello "  ..  name)
-      playerPoints[name] = 0
-      print( name  ..  " has "  ..  playerPoints[name] ..  " points.")
-      end
-   ```
+```lua
+local function setPoints(newPlayer)
+	local name = newPlayer.Name
+	print("hello " .. name)
+	playerPoints[name] = 0
+	print(name .. " has " .. playerPoints[name] .. " points.")
+end
+```
 
 6. Run the project and look into the output editor.
 
 ```lua title="Finished script"
-   Players = game:GetService("Players")
+local Players = game:GetService("Players")
 
-   local playerPoints = {
+local playerPoints = {
 
-   }
+}
 
-   local function setPoints(newPlayer)
-      local name = newPlayer.Name
-      print("hello " .. name)
-      playerPoints[name] = 0
-      print( name .. " has " ..playerPoints[name] .. " points.")
-   end
+local function setPoints(newPlayer)
+	local name = newPlayer.Name
+	print("hello " .. name)
+	playerPoints[name] = 0
+	print(name .. " has " .. playerPoints[name] .. " points.")
+end
 
-   Players.PlayerAdded:Connect(setPoints)
+Players.PlayerAdded:Connect(setPoints)
 ```
 
 ### Optional Challenges
@@ -216,30 +215,30 @@ Below are some challenges that apply to using dictionaries in different ways. Se
 `pairs()` is a function that's often used to iterate through **dictionaries**. An example is seen below.
 
 ```lua
- local myDictionary = {
-  ["Blue Player"] = "Ana",
-  ["Gold Player"] = "Binh",
-  ["Red Player"] = "Cate",
- }
+local myDictionary = {
+	["Blue Player"] = "Ana",
+	["Gold Player"] = "Binh",
+	["Red Player"] = "Cate",
+}
 
- for key, value in pairs(myDictionary) do
-   print(key .. " is " .. value)
- end
+for key, value in pairs(myDictionary) do
+	print(key .. " is " .. value)
+end
 ```
 
 `pairs()` can be used to work with a dictionary element's key, value, or both. In the for loop below, the first variable is the key. The second variable is the value. The dictionary that you want to work with is passed in to `pairs()`.
 
 ```lua
 local inventory = {
-    ["Gold Bricks"] = 43,
-    Carrots = 3,
-    Torches  = 2,
+	["Gold Bricks"] = 43,
+	Carrots = 3,
+	Torches = 2,
 }
 
 print("You have:")
 
 for itemName, itemValue in pairs(inventory) do
-    print(itemValue, itemName)
+	print(itemValue, itemName)
 end
 ```
 

--- a/content/en-us/tutorials/fundamentals/coding-5/intro-to-dictionaries.md
+++ b/content/en-us/tutorials/fundamentals/coding-5/intro-to-dictionaries.md
@@ -43,9 +43,9 @@ local partList = {
 print(partList[redPart])
 ```
 
- <Alert severity="warning">
- Use consistent data types for dictionary keys. Mixing data types, such as using both strings and variables for keys, can lead to inconsistent results when manipulating the array and confuse other coders.
- </Alert>
+<Alert severity="warning">
+Use consistent data types for dictionary keys. Mixing data types, such as using both strings and variables for keys, can lead to inconsistent results when manipulating the array and confuse other coders.
+</Alert>
 
 ## Creating a Dictionary
 
@@ -168,9 +168,9 @@ Dictionaries can interact with pre-existing variables declared in other parts of
 	end
 	```
 
-<Alert severity="warning">
-Since `name` was created as a variable, it can be accessed with the actual variable name. If `name` had been simply a key name, it would need to be accessed the same as other strings, playerPoints["name"]
-</Alert>
+	<Alert severity="warning">
+	Since `name` was created as a variable, it can be accessed with the actual variable name. If `name` had been simply a key name, it would need to be accessed the same as other strings, playerPoints["name"]
+	</Alert>
 
 5. Use `name` to print the name of the player and playerPoints[name] to print the value of the key matching the variable.
 


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
Fixed spacing on "Intro to Dictionaries" page.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
