### PR TITLE
Remove extra space before defining function parameters

### DIFF
--- a/content/en-us/education/adventure-game-series/selling-items.md
+++ b/content/en-us/education/adventure-game-series/selling-items.md
@@ -101,7 +101,7 @@ To use the platform, the script needs a function to check if any players touch i
    ```lua
    local Players = game:GetService("Players")
 
-   local function onTouch (partTouched)
+   local function onTouch(partTouched)
      local character = partTouched.Parent
      local player = Players:GetPlayerFromCharacter(character)
      if player then

--- a/content/en-us/luau/metatables.md
+++ b/content/en-us/luau/metatables.md
@@ -303,7 +303,7 @@ local function mathProblem(num)
 end
 
 local metatable = {
-   __index = function (object, key)
+   __index = function(object, key)
    	local num = mathProblem(key)
    	object[key] = num
    	return num

--- a/content/en-us/luau/scope.md
+++ b/content/en-us/luau/scope.md
@@ -11,7 +11,7 @@ Scripts cannot access global and local variables or functions in other scripts. 
 
 ```lua
 local helloWorld = 'Hello World!'
-local function printHelloWorld ()
+local function printHelloWorld()
 	print(helloWorld)
 end
 printHelloWorld() -- Hello World!

--- a/content/en-us/reference/engine/classes/HumanoidDescription.yaml
+++ b/content/en-us/reference/engine/classes/HumanoidDescription.yaml
@@ -1833,7 +1833,7 @@ events:
 
       ```lua
       local hd = Instance.new("HumanoidDescription")
-      hd.EquippedEmotesChanged:Connect(function (equippedEmotes)
+      hd.EquippedEmotesChanged:Connect(function(equippedEmotes)
           print(("We have %d emotes equipped"):format(#equippedEmotes))
           for _, t in equippedEmotes do
               print(("In slot %d: emote %s is equipped"):format(t.Slot, t.Name))

--- a/content/en-us/reference/engine/classes/Player.yaml
+++ b/content/en-us/reference/engine/classes/Player.yaml
@@ -2413,10 +2413,10 @@ events:
       end
 
       local function onPlayerAdded(player)
-      	player.CharacterAdded:Connect(function ()
+      	player.CharacterAdded:Connect(function()
       		onCharacterSpawned(player)
       	end)
-      	player.CharacterRemoving:Connect(function ()
+      	player.CharacterRemoving:Connect(function()
       		onCharacterDespawned(player)
       	end)
       end

--- a/content/en-us/reference/engine/classes/StarterGui.yaml
+++ b/content/en-us/reference/engine/classes/StarterGui.yaml
@@ -892,7 +892,7 @@ methods:
       local maxAttempts = 10
 
       while (tries < maxAttempts) do
-      	local success,result = pcall(function ()
+      	local success,result = pcall(function()
       		StarterGui:SetCore("CoreGuiChatConnections",ChatConnections)
       	end)
       	if success then

--- a/content/en-us/reference/engine/classes/TestService.yaml
+++ b/content/en-us/reference/engine/classes/TestService.yaml
@@ -37,11 +37,11 @@ description: |
   	</tr>
   	<tr>
   		<td>RBX_CHECK_THROW(CODE)</td>
-  		<td>pcall(function () CODE end) == false</td>
+  		<td>pcall(function() CODE end) == false</td>
   	</tr>
   	<tr>
   		<td>RBX_CHECK_NO_THROW(CODE)</td>
-  		<td>pcall(function () CODE end) == true</td>
+  		<td>pcall(function() CODE end) == true</td>
   	</tr>
   	<tr>
   		<td>RBX_CHECK_EQUAL(a,b)</td>
@@ -89,11 +89,11 @@ description: |
   	</tr>
   	<tr>
   		<td>RBX_REQUIRE_THROW(CODE)</td>
-  		<td>pcall(function () CODE end) == false</td>
+  		<td>pcall(function() CODE end) == false</td>
   	</tr>
   	<tr>
   		<td>RBX_REQUIRE_NO_THROW(CODE)</td>
-  		<td>pcall(function () CODE end) == true</td>
+  		<td>pcall(function() CODE end) == true</td>
   	</tr>
   	<tr>
   		<td>RBX_REQUIRE_EQUAL(a,b)</td>
@@ -140,11 +140,11 @@ description: |
   	</tr>
   	<tr>
   		<td>RBX_WARN_THROW(CODE)</td>
-  		<td>pcall(function () CODE end) == false</td>
+  		<td>pcall(function() CODE end) == false</td>
   	</tr>
   	<tr>
   		<td>RBX_WARN_NO_THROW(CODE)</td>
-  		<td>pcall(function () CODE end) == true</td>
+  		<td>pcall(function() CODE end) == true</td>
   	</tr>
   	<tr>
   		<td>RBX_WARN_EQUAL(a,b)</td>

--- a/content/en-us/reference/engine/libraries/string.yaml
+++ b/content/en-us/reference/engine/libraries/string.yaml
@@ -392,7 +392,7 @@ functions:
       -- Replacement table
       string.gsub("I play Roblox.", "%w+", {I="Je", play="joue à"}) --> Je joue à Roblox. 3
       -- Replacement function
-      string.gsub("I have 2 cats.", "%d+", function (n) return tonumber(n) * 12 end) --> I have 24 cats. 1
+      string.gsub("I have 2 cats.", "%d+", function(n) return tonumber(n) * 12 end) --> I have 24 cats. 1
       -- Replace only twice
       string.gsub("aaa", "a", "b", 2) --> "bba", 2
       ```

--- a/content/en-us/reference/engine/libraries/task.yaml
+++ b/content/en-us/reference/engine/libraries/task.yaml
@@ -233,7 +233,7 @@ functions:
       return a thread to cancel them before they are resumed. For example:
 
       ```lua
-      local thread = task.delay(5, function ()
+      local thread = task.delay(5, function()
         print("Hello world!")
       end)
 

--- a/content/en-us/resources/the-mystery-of-duvall-drive/supporting-systems.md
+++ b/content/en-us/resources/the-mystery-of-duvall-drive/supporting-systems.md
@@ -108,7 +108,7 @@ Some grabbable objects are important for gameplay, such as seals, and we didn't 
 In a few missions, we teleport players a short distance within a mission, such as [respawning players](../../resources/the-mystery-of-duvall-drive/main-design-requirements.md#respawning-players) who fall off a spinning platform. To simplify setting up this type of teleportation, which we call "Portals" in script, a helper function `ProcessPortal` in **DemoUtils** is used. For example, if P1 is the part defining the initial trigger, and P2 is the part defining destination player transform, the following code snippet could define such portal functionality:
 
 ```lua
-P1.Touched:Connect(function (otherPart) utils.ProcessPortal(otherPart, P2) end)
+P1.Touched:Connect(function(otherPart) utils.ProcessPortal(otherPart, P2) end)
 ```
 
 **ProcessPortal** handles checking that otherPart is a human, teleporting the player through a `Datatype.CFrame` coordinate change, and invoking a small cutscene to hide the transition using a **Teleport_Jump** event in [**EventManager**](../../resources/the-mystery-of-duvall-drive/foundational-gameplay-systems.md#eventmanager).

--- a/content/en-us/scripting/scheduler.md
+++ b/content/en-us/scripting/scheduler.md
@@ -21,8 +21,8 @@ The following table lists the relevant legacy global methods and their preferred
 | `wait(n)`                               | `Library.task.wait()\|task.wait(n)`                |                                                    |
 | `spawn(f)`                              | `Library.task.defer()\|task.defer(f)`              | `Library.task.delay()\|task.delay(0, f)`           |
 | `delay(n, f)`                           | `Library.task.delay()\|task.delay(n, f)`           |                                                    |
-| `spawn(function () f(uv1, ...) end)`    | `Library.task.defer()\|task.defer(f, uv1, ...)`    | `Library.task.delay()\|task.delay(0, f, uv1, ...)` |
-| `delay(n, function () f(uv1, ...) end)` | `Library.task.delay()\|task.delay(n, f, uv1, ...)` |                                                    |
+| `spawn(function() f(uv1, ...) end)`    | `Library.task.defer()\|task.defer(f, uv1, ...)`    | `Library.task.delay()\|task.delay(0, f, uv1, ...)` |
+| `delay(n, function() f(uv1, ...) end)` | `Library.task.delay()\|task.delay(n, f, uv1, ...)` |                                                    |
 
 #### task.spawn
 
@@ -65,7 +65,7 @@ print("B")
 Since the actual delay time may vary, the following code sample illustrates how you can calculate it by passing the current time as an argument:
 
 ```lua
-task.delay(2, function (scheduledTime)
+task.delay(2, function(scheduledTime)
     print(os.clock() - scheduledTime) --> 2.038702
 end, os.clock())
 ```

--- a/content/en-us/tutorials/fundamentals/coding-4/creating-a-timed-bridge.md
+++ b/content/en-us/tutorials/fundamentals/coding-4/creating-a-timed-bridge.md
@@ -301,7 +301,7 @@ local function startTimer()
 
 end
 
-local function buttonPressed (partTouched)
+local function buttonPressed(partTouched)
 	local character = partTouched.Parent
 	local humanoid = character:FindFirstChildWhichIsA("Humanoid")
 	print("part touched")


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
Removed extra space before defining function parameters

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
