### PR TITLE
Update gotham and arial fonts note

### DIFF
--- a/content/en-us/reference/engine/datatypes/Font.yaml
+++ b/content/en-us/reference/engine/datatypes/Font.yaml
@@ -14,7 +14,7 @@ description: |
   `Datatype.Font` is used by the `Class.TextLabel.FontFace`,
   `Class.TextButton.FontFace`, and `Class.TextBox.FontFace` properties.
 
-  **Note that Gotham and Arial have been removed. See the
+  **Note that Gotham and Arial have been replaced by Montserrat and Arimo. See the
   [forum announcement](https://devforum.roblox.com/t/introducing-builder-font-deprecating-gotham-and-arial/2868222)
   for more information.**
 

--- a/content/en-us/reference/engine/datatypes/Font.yaml
+++ b/content/en-us/reference/engine/datatypes/Font.yaml
@@ -14,7 +14,7 @@ description: |
   `Datatype.Font` is used by the `Class.TextLabel.FontFace`,
   `Class.TextButton.FontFace`, and `Class.TextBox.FontFace` properties.
 
-  **Note that Gotham and Arial will be removed in the near future. See the
+  **Note that Gotham and Arial have been removed. See the
   [forum announcement](https://devforum.roblox.com/t/introducing-builder-font-deprecating-gotham-and-arial/2868222)
   for more information.**
 


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
Gotham and Arial have been replaced by Montserrat and Arimo.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
https://devforum.roblox.com/t/introducing-builder-font-deprecating-gotham-and-arial/2868222/372

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
