### PR TITLE
fix RotationCurveKey.Value type in docs

### DIFF
--- a/content/en-us/reference/engine/datatypes/RotationCurveKey.yaml
+++ b/content/en-us/reference/engine/datatypes/RotationCurveKey.yaml
@@ -74,7 +74,7 @@ properties:
     tags: []
     deprecation_message: ''
   - name: RotationCurveKey.Value
-    type: number
+    type: CFrame
     summary: |
       The `Datatype.CFrame` value of this `Datatype.RotationCurveKey`.
     description: |


### PR DESCRIPTION
## Changes

changed "type: number" to "type: CFrame"

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
