### PR TITLE
Correct text regarding eligibility calculation for ads publishing

### DIFF
--- a/content/en-us/production/monetization/immersive-ads.md
+++ b/content/en-us/production/monetization/immersive-ads.md
@@ -96,7 +96,7 @@ Experiences must meet the following criteria to be eligible to be an ad publishe
 - Your experience must be **Public**. If a publisher makes the experience Private, the experience will lose eligibility.
 - You must complete the **Experience Guidelines Questionnaire** for your experience.
 - Your experience must maintain **2,000 unique visitors per month**.
-  - This is calculated on the 2nd of every month, based on visitors in the most recent 28 calendar days.
+  - This is calculated and updated monthly, based on visitor data.
   - Bots cannot be included in visitor counts.
 - You must comply with the [Roblox Terms of Use](https://en.help.roblox.com/hc/en-us/articles/115004647846-Roblox-Terms-of-Use), the [Community Standards](https://en.help.roblox.com/hc/en-us/articles/203313410-Roblox-Community-Standards), and the [Advertising Standards](https://en.help.roblox.com/hc/en-us/articles/13722260778260-Advertising-Standards#publisher-integrity).
 

--- a/content/en-us/production/monetization/immersive-ads.md
+++ b/content/en-us/production/monetization/immersive-ads.md
@@ -96,7 +96,7 @@ Experiences must meet the following criteria to be eligible to be an ad publishe
 - Your experience must be **Public**. If a publisher makes the experience Private, the experience will lose eligibility.
 - You must complete the **Experience Guidelines Questionnaire** for your experience.
 - Your experience must maintain **2,000 unique visitors per month**.
-  - This is calculated based on visitors in the most recent 30 calendar days for which Roblox has complete data.
+  - This is calculated on the 2nd of every month, based on visitors in the most recent 28 calendar days.
   - Bots cannot be included in visitor counts.
 - You must comply with the [Roblox Terms of Use](https://en.help.roblox.com/hc/en-us/articles/115004647846-Roblox-Terms-of-Use), the [Community Standards](https://en.help.roblox.com/hc/en-us/articles/203313410-Roblox-Community-Standards), and the [Advertising Standards](https://en.help.roblox.com/hc/en-us/articles/13722260778260-Advertising-Standards#publisher-integrity).
 


### PR DESCRIPTION
## Changes

We typically get [dev forum reports/bugs](https://devforum.roblox.com/t/immersive-ads-not-enabled-for-games-with-over-2000-mau/3045190) stemming from confusion around how/when we calculate eligibility to publish ads. This change in text should help clarify our calculation mechanism.

[Slack thread](https://roblox.slack.com/archives/C06Q9288KBP/p1720462991946199) to arrive at updated text.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
