### PR TITLE
Remove occurences of Class.CoreScript reference

### DIFF
--- a/content/en-us/reference/engine/classes/StarterGui.yaml
+++ b/content/en-us/reference/engine/classes/StarterGui.yaml
@@ -211,12 +211,12 @@ methods:
   - name: StarterGui:SetCore
     summary: |
       Allows you to perform certain interactions with Roblox's
-      `Class.CoreScript|CoreScripts`.
+      CoreScripts.
     description: |
       SetCore (not to be confused with
       `Class.StarterGui:SetCoreGuiEnabled()|SetCoreGuiEnabled`) exposes a
       variety of functionality defined by Roblox's
-      `Class.CoreScript|CoreScripts`, such as sending notifications, toggling
+      CoreScripts, such as sending notifications, toggling
       notifications for badges/points, defining a callback for the reset button
       or toggling the topbar. The first parameter to SetCore is a string that
       selects the functionality with which the call will interact: a CoreScript
@@ -904,10 +904,10 @@ methods:
     thread_safety: Unsafe
   - name: StarterGui:GetCore
     summary: |
-      Returns a variable that has been specified by a Roblox `Class.CoreScript`.
+      Returns a variable that has been specified by a Roblox CoreScript.
     description: |
       GetCore returns data set or made available by Roblox's
-      `Class.CoreScript|CoreScripts`. The first and only parameter is a string
+      CoreScripts. The first and only parameter is a string
       that selects the information to be fetched. The following sections
       describe the strings and the data they return by this function.
 


### PR DESCRIPTION
## Changes

CoreScript is not a class but a concept of specially privileged script, there is nothing to be referenced (especially this wouldn't be a non-existing `CoreScript` class). So far there on the creator hub documentation there is no explanation what CoreScripts really are and there doesn't seem to be any place for that at the moment.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
