### PR TITLE
Add missing CoreScript reference

### DIFF
--- a/content/en-us/reference/engine/classes/CoreScript.yaml
+++ b/content/en-us/reference/engine/classes/CoreScript.yaml
@@ -1,0 +1,19 @@
+name: CoreScript
+type: class
+category: Scripting
+memory_category: Script
+summary: |
+  An object that contains and runs Roblox-authored Lua code on the server.
+description: |
+  A `Class.CoreScript` is a Lua code container that acts like a `Class.Script` but may also access internal Roblox properties and methods. It is used internally in the core functionality implementation (such as the backspace and in-game menu).
+code_samples:
+inherits:
+  - BaseScript
+tags:
+  - NotCreatable
+  - NotReplicated
+deprecation_message: ''
+properties: []
+methods: []
+events: []
+callbacks: []


### PR DESCRIPTION
## Changes

Added missing CoreScript class reference. It is mentioned on numerous pages eg. https://create.roblox.com/docs/reference/engine/classes/StarterGui#SetCore but the class reference doesn't exist.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
