### PR TITLE
Remove CoreScript class references and standardize it's naming convention

### DIFF
--- a/content/en-us/reference/engine/classes/AudioDeviceInput.yaml
+++ b/content/en-us/reference/engine/classes/AudioDeviceInput.yaml
@@ -53,7 +53,7 @@ properties:
       Controls whether the physical device is actively recording.
     description: |
       Controls whether the physical device is actively recording. This property
-      is only set by Roblox core scripts, but it may be read by user scripts.
+      is only set by Roblox's Core Scripts, but it may be read by user scripts.
       Generally, an `Class.AudioDeviceInput` may only be producing sound if
       `Class.AudioDeviceInput.Active|Active` is true **and**
       `Class.AudioDeviceInput.Muted|Muted` is false.

--- a/content/en-us/reference/engine/classes/ContextActionService.yaml
+++ b/content/en-us/reference/engine/classes/ContextActionService.yaml
@@ -65,7 +65,7 @@ description: |
 
   To see a list of actions and their bound inputs, you can inspect the "Action
   Bindings" tab in the Developer Console (F9 while in game). This shows all
-  bindings - including those bound by Roblox CoreScripts and default
+  bindings - including those bound by Roblox's Core Scripts and default
   camera/control scripts too. This is useful for debugging: check if your
   actions are being bound/unbound at the correct times, or if some other action
   is stealing input from your actions. For example, if you are attempting to

--- a/content/en-us/reference/engine/classes/DataModel.yaml
+++ b/content/en-us/reference/engine/classes/DataModel.yaml
@@ -879,7 +879,7 @@ events:
       GraphicsQualityChangeRequest does not provide the current graphics quality
       level or cover all updates to the graphics quality. For example, changes
       made in the core GUI escape menu are not registered. This event is
-      intended to be used by Roblox `Class.CoreScript|Core Scripts` to update
+      intended to be used internally in Roblox's Core Scripts to update
       the graphics quality and display notifications.
 
       You can retrieve a user's `Enum.SavedQualitySetting` using

--- a/content/en-us/reference/engine/classes/GuiService.yaml
+++ b/content/en-us/reference/engine/classes/GuiService.yaml
@@ -7,15 +7,15 @@ summary: |
   `Class.GuiObject` is currently being selected by the gamepad navigator. It
   also allows clients to check if Roblox's main menu is currently open.
 
-  This service has a lot of hidden members, which are mainly used internally by
-  Roblox's `Class.CoreScript|CoreScripts`.
+  This service has a lot of hidden members, which are mainly used internally in
+  Roblox's Core Scripts.
 description: |
   The GuiService is a service which currently allows developers to control what
   `Class.GuiObject` is currently being selected by the gamepad navigator. It
   also allows clients to check if Roblox's main menu is currently open.
 
-  This service has a lot of hidden members, which are mainly used internally by
-  Roblox's `Class.CoreScript|CoreScripts`.
+  This service has a lot of hidden members, which are mainly used internally in
+  Roblox's Core Scripts.
 code_samples:
 inherits:
   - Instance

--- a/content/en-us/reference/engine/classes/Instance.yaml
+++ b/content/en-us/reference/engine/classes/Instance.yaml
@@ -1350,7 +1350,7 @@ methods:
       - No spaces or unique symbols are allowed.
       - Strings must be 100 characters or less.
       - Names are not allowed to start with **RBX** unless the caller is a
-        Roblox core script (reserved for Roblox).
+        Roblox's Core Script (reserved for Roblox).
 
       When attempting to set an attribute to an unsupported type, an error will
       be thrown.

--- a/content/en-us/reference/engine/classes/LocalizationService.yaml
+++ b/content/en-us/reference/engine/classes/LocalizationService.yaml
@@ -29,8 +29,7 @@ properties:
       scripts and GUI.
     description: |
       This property shows the locale id used for the localization of core and
-      internal features such as `Class.CoreGui` and
-      `Class.CoreScript|CoreScripts`.
+      internal features such as `Class.CoreGui` and Core Scripts.
 
       This will return a string with the two letter code (for example, "en-us")
       for the locale.
@@ -75,10 +74,10 @@ methods:
   - name: LocalizationService:GetCorescriptLocalizations
     summary: |
       Returns a list of `Class.LocalizationTable` objects used for localizing
-      CoreScripts.
+      Roblox's Core Scripts.
     description: |
       Returns a list of `Class.LocalizationTable` objects used for localizing
-      CoreScripts.
+      Roblox's Core Scripts.
     code_samples:
     parameters: []
     returns:

--- a/content/en-us/reference/engine/classes/LuaSourceContainer.yaml
+++ b/content/en-us/reference/engine/classes/LuaSourceContainer.yaml
@@ -4,11 +4,11 @@ category:
 memory_category: Instances
 summary: |
   The base class for all objects which contain Lua code. `Class.Script`,
-  `Class.LocalScript`, `Class.ModuleScript` and `Class.CoreScript` all inherit
+  `Class.LocalScript`, `Class.ModuleScript` and internal CoreScript class all inherit
   from LuaSourceContainer.
 description: |
   The base class for all objects which contain Lua code. `Class.Script`,
-  `Class.LocalScript`, `Class.ModuleScript` and `Class.CoreScript` all inherit
+  `Class.LocalScript`, `Class.ModuleScript` and internal CoreScript class all inherit
   from LuaSourceContainer.
 code_samples:
 inherits:

--- a/content/en-us/reference/engine/classes/Player.yaml
+++ b/content/en-us/reference/engine/classes/Player.yaml
@@ -777,7 +777,7 @@ properties:
 
       This property can only be read from to determine membership (it cannot be
       set to another membership type). The property can only be changed via
-      `Class.CoreScript|CoreScripts` using `Class.Player:SetMembershipType()` -
+      Roblox's internal Core Scripts using `Class.Player:SetMembershipType()` -
       which are not accessible.
     code_samples:
       - check-membership-status

--- a/content/en-us/reference/engine/classes/StarterGui.yaml
+++ b/content/en-us/reference/engine/classes/StarterGui.yaml
@@ -210,19 +210,18 @@ methods:
     thread_safety: Unsafe
   - name: StarterGui:SetCore
     summary: |
-      Allows you to perform certain interactions with Roblox's
-      `Class.CoreScript|CoreScripts`.
+      Allows you to perform certain interactions with Roblox's Core Scripts.
     description: |
       SetCore (not to be confused with
       `Class.StarterGui:SetCoreGuiEnabled()|SetCoreGuiEnabled`) exposes a
       variety of functionality defined by Roblox's
-      `Class.CoreScript|CoreScripts`, such as sending notifications, toggling
+      Core Scripts, such as sending notifications, toggling
       notifications for badges/points, defining a callback for the reset button
       or toggling the topbar. The first parameter to SetCore is a string that
-      selects the functionality with which the call will interact: a CoreScript
+      selects the functionality with which the call will interact: a Core Script
       must have registered such a string already (if one hasn't, an error is
       raised). It may be necessary to make multiple calls to SetCore using
-      `pcall` in case the respective CoreScript has yet to load (or if it has
+      `pcall` in case the respective Core Script has yet to load (or if it has
       been disabled entirely).
 
       The following table describes the strings that may be accepted as the
@@ -855,7 +854,7 @@ methods:
         default:
         summary: |
           Selects the functionality with which the call will interact: a
-          CoreScript must have registered such a string already (if one hasn't,
+          Core Script must have registered such a string already (if one hasn't,
           an error is raised).
       - name: value
         type: Variant
@@ -904,14 +903,14 @@ methods:
     thread_safety: Unsafe
   - name: StarterGui:GetCore
     summary: |
-      Returns a variable that has been specified by a Roblox `Class.CoreScript`.
+      Returns a variable that has been specified by a Roblox's Core Script.
     description: |
       GetCore returns data set or made available by Roblox's
-      `Class.CoreScript|CoreScripts`. The first and only parameter is a string
+      Core Scripts. The first and only parameter is a string
       that selects the information to be fetched. The following sections
       describe the strings and the data they return by this function.
 
-      Each of these is registered by a CoreScript and calling this function may
+      Each of these is registered by a Core Script and calling this function may
       yield. Many of these also register an equivalent
       `Class.StarterGui:SetCore()|SetCore` function (these are marked with an
       asterisk).

--- a/content/en-us/reference/engine/classes/UserInputService.yaml
+++ b/content/en-us/reference/engine/classes/UserInputService.yaml
@@ -2860,10 +2860,10 @@ events:
       As this event only fires locally, it can only be used in a
       `Class.LocalScript`.
 
-      `Class.CoreScript|Core scripts` use similar logic to zoom the user's
+      Roblox's Core Scripts use similar logic to zoom the user's
       camera when a user pinches their fingers on a mobile device. Best practice
       for this event is to use it when creating a mobile camera system to
-      override the default core script.
+      override the default Core Script behaviour.
 
       See also:
 
@@ -2943,10 +2943,10 @@ events:
       As this event only fires locally, it can only be used in a
       `Class.LocalScript`.
 
-      The core scripts that control the user's camera on a mobile device use
+      Roblox's Core Scripts that control the user's camera on a mobile device use
       code that functions similarly to this event. Best practice for this event
       is to use it when creating a mobile camera system to override the default
-      core scripts.
+      Core Script behaviour.
 
       See also:
 

--- a/content/en-us/reference/engine/classes/VirtualInputManager.yaml
+++ b/content/en-us/reference/engine/classes/VirtualInputManager.yaml
@@ -7,7 +7,7 @@ summary: |
 description: |
   VirtualInputManager is an internal service used by Roblox to record inputs and
   play them back during performance benchmarking tests. This service's API can
-  only be used by `Class.CoreScript`.
+  only be used internally in Roblox's Core Scripts.
 code_samples:
 inherits:
   - Instance

--- a/content/en-us/reference/engine/enums/CameraType.yaml
+++ b/content/en-us/reference/engine/enums/CameraType.yaml
@@ -47,7 +47,7 @@ items:
     deprecation_message: ''
   - name: Custom
     summary: |
-      Default mode used by Roblox Core Scripts.
+      Default mode used by Roblox's Core Scripts.
     value: 5
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/DeveloperMemoryTag.yaml
+++ b/content/en-us/reference/engine/enums/DeveloperMemoryTag.yaml
@@ -37,7 +37,7 @@ items:
   - name: LuaHeap
     value: 4
     summary: |
-      All of the data in Lua. this includes everything happening in CoreScripts,
+      All of the data in Lua. this includes everything happening in Roblox's Core Scripts,
       the built-in data types, etc.
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/DeviceType.yaml
+++ b/content/en-us/reference/engine/enums/DeviceType.yaml
@@ -6,7 +6,7 @@ description: |
   The DeviceType Enum is used to determine the category of devices that a client
   belongs to.
 
-  Currently this can only be used in `Class.CoreScript|CoreScripts`.
+  Currently this can only be used internally in Roblox's Core Scripts.
 code_samples:
 tags: []
 deprecation_message: ''

--- a/content/en-us/reference/engine/enums/Platform.yaml
+++ b/content/en-us/reference/engine/enums/Platform.yaml
@@ -4,7 +4,7 @@ summary: |
   Host operating system of the client.
 description: |
   The Platform Enum is used to determine the operating system of the client.
-  Currently this can only be used in `Class.CoreScript|CoreScripts`.
+  Currently this can only be used internally in Roblox's Core Scripts.
 code_samples:
 tags: []
 deprecation_message: ''

--- a/content/en-us/reference/engine/enums/TouchCameraMovementMode.yaml
+++ b/content/en-us/reference/engine/enums/TouchCameraMovementMode.yaml
@@ -12,13 +12,13 @@ deprecation_message: ''
 items:
   - name: Default
     summary: |
-      Default mode used by Roblox Core Scripts.
+      Default mode used by Roblox's Core Scripts.
     value: 0
     tags: []
     deprecation_message: ''
   - name: Classic
     summary: |
-      Default mode used by Roblox Core Scripts.
+      Default mode used by Roblox's Core Scripts.
     value: 1
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/globals/RobloxGlobals.yaml
+++ b/content/en-us/reference/engine/globals/RobloxGlobals.yaml
@@ -56,7 +56,7 @@ properties:
     description: |
       A reference to the script object that is executing the code you are
       writing. It can be either a `Class.Script`, a `Class.LocalScript`, or a
-      `Class.ModuleScript` (and sometimes a `Class.CoreScript`). This variable
+      `Class.ModuleScript` (and sometimes a CoreScript). This variable
       is not available when executing code from Roblox Studio's command bar.
     tags:
     code_samples:

--- a/content/en-us/studio/optimization/memory-usage.md
+++ b/content/en-us/studio/optimization/memory-usage.md
@@ -59,7 +59,7 @@ To view memory allocation:
      </tr>
      <tr>
        <td>**LuaHeap**</td>
-       <td>Heap memory for both core scripts (scripts that ship with the Roblox client) and custom scripts.</td>
+       <td>Heap memory for both Core Scripts (scripts that ship with the Roblox client) and custom scripts.</td>
      </tr>
      <tr>
        <td>**Script**</td>


### PR DESCRIPTION
## Changes

The commit removes CoreScript class references (which were broken) and standardizes CoreScript naming convention - using `CoreScript` to class and `Core Scripts` when referring to Roblox's scripts that implement core functionalities.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
