### PR TITLE
Fix Restaurant Soup Simulator Example

### DIFF
--- a/content/en-us/tutorials/fundamentals/coding-5/pairs-and-ipairs.md
+++ b/content/en-us/tutorials/fundamentals/coding-5/pairs-and-ipairs.md
@@ -93,34 +93,34 @@ Use `pairs()` to see what was picked, and then `ipairs()` to print the list of i
 
    ```lua
    -- Customer's soup
-   local isInSoup = {}
+   local selectedIngredients = {}
    ```
 
 3. Use `pairs()` to check if each ingredient in the dictionary is marked true or false. If true, add the ingredient to soup.
 
    ```lua
    -- Customer's soup
-   local isInSoup = {}
+   local selectedIngredients = {}
 
    -- Adds customer's choices to their soup
    for menuChoice, value in pairs(menu) do
    	if value then
-   		table.insert(isInSoup, menuChoice)
+   		table.insert(selectedIngredients, menuChoice)
    	end
    end
    ```
 
 4. Repeat the order back to the customer. In the script, code the following below.
 
-   - Check if there is a menu item in `isInSoup`. If so, print `"You ordered soup with: "`.
-   - Use `ipairs()` to go through the `isInSoup` array and print each ingredient.
+   - Check if there is a menu item in `selectedIngredients`. If so, print `"You ordered soup with: "`.
+   - Use `ipairs()` to go through the `selectedIngredients` array and print each ingredient.
    - Test by changing at least one menu item to true.
 
    ```lua
-   -- Prints soup order from "isInSoup"
-   if isInSoup then
+   -- Prints soup order from "selectedIngredients"
+   if #selectedIngredients > 0 then
    	print("You ordered soup with: ")
-   	for index, soupIngredient in ipairs(isInSoup) do
+   	for index, soupIngredient in ipairs(selectedIngredients) do
    		print(soupIngredient)
    	end
    end
@@ -129,9 +129,9 @@ Use `pairs()` to see what was picked, and then `ipairs()` to print the list of i
 5. In the if statement that checks if there is a menu item, add an else condition which tells customers if no ingredients were selected.
 
    ```lua
-   if isInSoup then
+   if #selectedIngredients > 0 then
    	print("You ordered soup with: ")
-   	for index, soupIngredient in ipairs(isInSoup) do
+   	for index, soupIngredient in ipairs(selectedIngredients) do
    		print(soupIngredient)
    	end
    else


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

This pull request updates the Restaurant Soup Simulator example on the pairs and ipairs docs page. The `isInSoup` table was renamed to `selectedIngredients` because the name `isInSoup` didn't make sense with how it was used, and the conditional at the end was fixed to check the length of the table (previously it always evaluated to true because the table did exist, but now it only evaluates to true when the table has at least one element).

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
