### PR TITLE
Corrected Priority Order for Animation States in Documentation

### DIFF
--- a/content/en-us/reference/engine/classes/AnimationTrack.yaml
+++ b/content/en-us/reference/engine/classes/AnimationTrack.yaml
@@ -149,8 +149,8 @@ properties:
       played over one another.
 
       The Priority property for `Class.AnimationTrack` defaults to how it was
-      set and published from Studio's Animation Editor. It uses the
-      AnimationPriority Enum, which has 7 priority levels.
+      set and published from Studio's [Animation Editor](../../../animation/editor.md). It uses
+      `Enum.AnimationPriority` which has 7 priority levels:
 
       1. Action4 (highest priority)
       2. Action3
@@ -160,8 +160,8 @@ properties:
       6. Idle
       7. Core (lowest priority)
 
-      Correctly set animation priorities, either through the editor or through
-      this property allow multiple animations to be played without them
+      Properly set animation priorities, either through the editor or through
+      this property, allow multiple animations to be played without them
       clashing. Where two playing animations direct the target to move the same
       limb in different ways, the `Class.AnimationTrack` with the highest
       priority will show. If both animations have the same priority, the weights

--- a/content/en-us/reference/engine/classes/AnimationTrack.yaml
+++ b/content/en-us/reference/engine/classes/AnimationTrack.yaml
@@ -152,13 +152,13 @@ properties:
       set and published from Studio's Animation Editor. It uses the
       AnimationPriority Enum, which has 7 priority levels.
 
-      1. Core (lowest priority)
-      2. Idle
-      3. Movement
+      1. Action4 (highest priority)
+      2. Action3
+      3. Action2
       4. Action
-      5. Action2
-      6. Action3
-      7. Action4 (highest priority)
+      5. Movement
+      6. Idle
+      7. Core (lowest priority)
 
       Correctly set animation priorities, either through the editor or through
       this property allow multiple animations to be played without them


### PR DESCRIPTION

## Changes
The current documentation for animation priorities lists the priorities in the following order:
1. Core (lowest priority)
2. Idle
3. Movement
4. Action
5. Action2
6. Action3
7. Action4 (highest priority)

However, this order is reversed compared to the actual Game Enum values where:
![Core](https://github.com/user-attachments/assets/542acfb8-4c9e-42c7-bff4-06783c8e9f33)
![Action4](https://github.com/user-attachments/assets/fd8bc7c6-a619-43f1-a9be-588c2462c19c)

Updated:
1. Action4 (highest priority)
2. Action3
3. Action2
4. Action
5. Movement
6. Idle
7. Core (lowest priority)

<!-- Please summarize your changes. -->
This update ensures that the documentation accurately represents the actual priority levels used in the game, thereby preventing confusion for developers.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
