### PR TITLE
(Enum.SurfaceType) rephrasing-and-deprecation-additions

### DIFF
--- a/content/en-us/reference/engine/enums/SurfaceType.yaml
+++ b/content/en-us/reference/engine/enums/SurfaceType.yaml
@@ -27,26 +27,25 @@ description: |
     specified joint creation mode
   - `Enum.JointCreationMode`, the way joints are created between two surfaces
 code_samples:
-tags:
- - Deprecated
+tags: []
 deprecation_message: |
   SurfaceType based joining is deprecated, leaving only visual changes to the appearence of the effected 'Class.Part'. This should not be used for future work.
 items:
   - name: Smooth
     summary: |
-     Adds no details on the surface.
+      Adds no details on the surface.
     value: 0
     tags: []
     deprecation_message: ''
   - name: Glue
     summary: |
-     Adds an X pattern across the surface.
+      Adds an X pattern across the surface.
     value: 1
     tags: []
     deprecation_message: ''
   - name: Weld
     summary: |
-     Adds an X pattern across the surface.
+      Adds an X pattern across the surface.
     value: 2
     tags: []
     deprecation_message: ''
@@ -58,13 +57,13 @@ items:
     deprecation_message: ''
   - name: Inlet
     summary: |
-     Adds square holes across the surface where studs would be.
+      Adds square holes across the surface where studs would be.
     value: 4
     tags: []
     deprecation_message: ''
   - name: Universal
     summary: |
-     Adds a checker pattern to the surface using Studs and Intlets.
+      Adds a checker pattern to the surface using Studs and Intlets.
     value: 5
     tags: []
     deprecation_message: ''
@@ -72,29 +71,25 @@ items:
     summary: |
       Adds a yellow hinge to the surface. Parts touching it would stick to the surface allowing for rotations using physics. This should not be used for future work, and should be replaced with a `Class.HingeConstraint` instead.
     value: 6
-    tags:
-     - Deprecated
+    tags: []
     deprecation_message: ''
   - name: Motor
     summary: |
       Functioned identically to a hinge with the addition of a grey ring.
     value: 7
-    tags:
-     - Deprecated
+    tags: []
     deprecation_message: ''
   - name: SteppingMotor
     summary: |
       Functioned identically to a motor. It may have functioned differently in
       the past, but that functionality is non-existant.
     value: 8
-    tags:
-     - Deprecated
+    tags: []
     deprecation_message: ''
   - name: SmoothNoOutlines
     summary: |
       Same as Smooth, but removed the _outlines_ of the surface. This no longer
       functions as outlines have been removed.
     value: 10
-    tags:
-     - Deprecated
+    tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/SurfaceType.yaml
+++ b/content/en-us/reference/engine/enums/SurfaceType.yaml
@@ -88,8 +88,8 @@ items:
     deprecation_message: ''
   - name: SmoothNoOutlines
     summary: |
-      Same as Smooth, but removed the _outlines_ of the surface. This no longer
-      functions as outlines have been removed.
+      Previously similar to **Smooth** with outlines but no longer relevant 
+      since outlines have been removed.
     value: 10
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/SurfaceType.yaml
+++ b/content/en-us/reference/engine/enums/SurfaceType.yaml
@@ -29,7 +29,7 @@ description: |
 code_samples:
 tags: []
 deprecation_message: |
-  SurfaceType based joining is deprecated, leaving only visual changes to the appearence of the effected 'Class.Part'. This should not be used for future work.
+  SurfaceType based joining is deprecated, leaving only visual changes to the effected 'Class.Part'. This should not be used for future work.
 items:
   - name: Smooth
     summary: |

--- a/content/en-us/reference/engine/enums/SurfaceType.yaml
+++ b/content/en-us/reference/engine/enums/SurfaceType.yaml
@@ -1,35 +1,16 @@
 name: SurfaceType
 type: enum
 summary: |
-  Used to determine how a surface should be displayed on a part and how
-  automatic surface joints should behave.
+  Used to determine how a surface should be displayed on a part and how automatic
+  surface joints should behave.
 description: |
-  Used to determine how a surface should be displayed on a part and how
-  automatic surface joints should behave.
-
-  ## Surface behavior
-
-  When surface joining is on, all planar touching surfaces of a `Class.Part` will weld together, regardless of SurfaceType. This does not affect Hinge, Motor, or SteppingMotor.
-
-  - Glue, Studs, Inlets, Universal, Weld, and Smooth surfaces will all create
-    Weld instances
-  - Spheres will not surface-weld to anything. The rounded sides of cylinders
-    will not surface-weld, but the flat end sides will.
-
-  ## Surface appearance
-
-  Stud, Inlet, Universal, Weld, and Glue Surface textures only appear on plastic material parts, both in-game and in Studio.
-
-  See also:
-
-  - `Class.Workspace:JoinToOutsiders()`, creates joints between the specified
-    parts and any touching parts depending on the parts' surfaces and the
-    specified joint creation mode
-  - `Enum.JointCreationMode`, the way joints are created between two surfaces
+  Used to determine how a surface should be displayed on a part and how automatic
+  surface joints should behave.
 code_samples:
 tags: []
 deprecation_message: |
-  **SurfaceType** joining is deprecated, leaving only visual changes on the affected `Class.Part`. It should not be used for future work.
+  **SurfaceType** joining is deprecated, leaving only visual changes on the
+  affected `Class.Part`. It should not be used for future work.
 items:
   - name: Smooth
     summary: |
@@ -69,7 +50,10 @@ items:
     deprecation_message: ''
   - name: Hinge
     summary: |
-      Adds a yellow hinge to the surface. Parts touching it stick to the surface, allowing for rotations using physics. This should not be used for future work and existing instances should be replaced with a `Class.HingeConstraint`.
+      Adds a yellow hinge to the surface. Parts touching it stick to the surface,
+      allowing for rotations using physics. This should not be used for future
+      work and existing instances should be replaced with a
+      `Class.HingeConstraint`.
     value: 6
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/SurfaceType.yaml
+++ b/content/en-us/reference/engine/enums/SurfaceType.yaml
@@ -9,9 +9,7 @@ description: |
 
   ## Surface behavior
 
-  When surface joining is on, all planar touching flat sides of parts will weld
-  together, regardless of SurfaceType. This does not affect Hinge, Motor,
-  SteppingMotor.
+  When surface joining is on, all planar touching surfaces of a `Class.Part` will weld together, regardless of SurfaceType. This does not affect Hinge, Motor, or SteppingMotor.
 
   - Glue, Studs, Inlets, Universal, Weld, and Smooth surfaces will all create
     Weld instances
@@ -20,8 +18,7 @@ description: |
 
   ## Surface appearance
 
-  Stud, Inlet, Universal, Weld, and Glue Surface textures only appear on plastic
-  material parts, both in-game and in Studio.
+  Stud, Inlet, Universal, Weld, and Glue Surface textures only appear on plastic material parts, both in-game and in Studio.
 
   See also:
 
@@ -30,71 +27,77 @@ description: |
     specified joint creation mode
   - `Enum.JointCreationMode`, the way joints are created between two surfaces
 code_samples:
-tags: []
-deprecation_message: ''
+tags:
+ - Deprecated
+deprecation_message: |
+  SurfaceType based joining is deprecated, leaving only visual changes to the appearence of the effected 'Class.Part'.
+  
+  This should not be used for future work.
 items:
   - name: Smooth
     summary: |
-      Makes the side appear without any surface detail (except for _outlines_).
+     Adds no details on the surface.
     value: 0
     tags: []
     deprecation_message: ''
   - name: Glue
     summary: |
-      Makes the side appear with thick diagonal "X"s.
+     Adds an X pattern across the surface.
     value: 1
     tags: []
     deprecation_message: ''
   - name: Weld
     summary: |
-      Makes the side appear with thick diagonal "X"s.
+     Adds an X pattern across the surface.
     value: 2
     tags: []
     deprecation_message: ''
   - name: Studs
     summary: |
-      Makes the side appear with square studs.
+      Adds square studs across the surface.
     value: 3
     tags: []
     deprecation_message: ''
   - name: Inlet
     summary: |
-      Makes the side appear with holes where studs would be.
+     Adds square holes across the surface where studs would be.
     value: 4
     tags: []
     deprecation_message: ''
   - name: Universal
     summary: |
-      Makes the side appear with both Studs and Inlets in a checker pattern.
+     Adds a checker pattern to the surface using Studs and Intlets.
     value: 5
     tags: []
     deprecation_message: ''
   - name: Hinge
     summary: |
-      Makes the side appear with a yellow hinge. Any part connected to this
-      hinge will stick to the side and rotate using physics, however, using
-      `Class.HingeConstraint` to join parts is preferred.
+      Adds a yellow hinge to the surface. Parts touching it would stick to the surface allowing for rotations using physics.
+      This should not be used for future work, and should be replaced with a `Class.HingeConstraint` instead.
     value: 6
-    tags: []
+    tags:
+     - Deprecated
     deprecation_message: ''
   - name: Motor
     summary: |
-      Acts the same as a Hinge, but has a grey ring around it and automatically
-      rotates any part connected to it, however, using `Class.HingeConstraint`
-      to join parts is preferred.
+      Functioned identically to a hinge with the addition of a grey ring.
     value: 7
-    tags: []
+    tags:
+     - Deprecated
     deprecation_message: ''
   - name: SteppingMotor
     summary: |
-      Functions identically to a motor. It may have functioned differently in
-      the past, but that functionality no longer seems to exist.
+      Functioned identically to a motor. It may have functioned differently in
+      the past, but that functionality is non-existant.
     value: 8
-    tags: []
+    tags:
+     - Deprecated
     deprecation_message: ''
   - name: SmoothNoOutlines
     summary: |
-      Same as Smooth, but removes the _outlines_ of the surface.
+      Same as Smooth, but removed the _outlines_ of the surface. This no longer
+      functions as outlines have been removed.
     value: 10
-    tags: []
+    tags:
+     - Deprecated
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/SurfaceType.yaml
+++ b/content/en-us/reference/engine/enums/SurfaceType.yaml
@@ -30,9 +30,7 @@ code_samples:
 tags:
  - Deprecated
 deprecation_message: |
-  SurfaceType based joining is deprecated, leaving only visual changes to the appearence of the effected 'Class.Part'.
-  
-  This should not be used for future work.
+  SurfaceType based joining is deprecated, leaving only visual changes to the appearence of the effected 'Class.Part'. This should not be used for future work.
 items:
   - name: Smooth
     summary: |
@@ -72,8 +70,7 @@ items:
     deprecation_message: ''
   - name: Hinge
     summary: |
-      Adds a yellow hinge to the surface. Parts touching it would stick to the surface allowing for rotations using physics.
-      This should not be used for future work, and should be replaced with a `Class.HingeConstraint` instead.
+      Adds a yellow hinge to the surface. Parts touching it would stick to the surface allowing for rotations using physics. This should not be used for future work, and should be replaced with a `Class.HingeConstraint` instead.
     value: 6
     tags:
      - Deprecated

--- a/content/en-us/reference/engine/enums/SurfaceType.yaml
+++ b/content/en-us/reference/engine/enums/SurfaceType.yaml
@@ -29,7 +29,7 @@ description: |
 code_samples:
 tags: []
 deprecation_message: |
-  SurfaceType based joining is deprecated, leaving only visual changes to the effected 'Class.Part'. This should not be used for future work.
+  **SurfaceType** joining is deprecated, leaving only visual changes on the affected `Class.Part`. It should not be used for future work.
 items:
   - name: Smooth
     summary: |
@@ -39,13 +39,13 @@ items:
     deprecation_message: ''
   - name: Glue
     summary: |
-      Adds an X pattern across the surface.
+      Adds an "X" pattern across the surface.
     value: 1
     tags: []
     deprecation_message: ''
   - name: Weld
     summary: |
-      Adds an X pattern across the surface.
+      Adds an "X" pattern across the surface.
     value: 2
     tags: []
     deprecation_message: ''
@@ -63,13 +63,13 @@ items:
     deprecation_message: ''
   - name: Universal
     summary: |
-      Adds a checker pattern to the surface using Studs and Intlets.
+      Adds a checker pattern to the surface using studs and inlets.
     value: 5
     tags: []
     deprecation_message: ''
   - name: Hinge
     summary: |
-      Adds a yellow hinge to the surface. Parts touching it would stick to the surface allowing for rotations using physics. This should not be used for future work, and should be replaced with a `Class.HingeConstraint` instead.
+      Adds a yellow hinge to the surface. Parts touching it stick to the surface, allowing for rotations using physics. This should not be used for future work and existing instances should be replaced with a `Class.HingeConstraint`.
     value: 6
     tags: []
     deprecation_message: ''
@@ -82,7 +82,7 @@ items:
   - name: SteppingMotor
     summary: |
       Functioned identically to a motor. It may have functioned differently in
-      the past, but that functionality is non-existant.
+      the past, but that functionality is non-existent.
     value: 8
     tags: []
     deprecation_message: ''


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

I made some changes to the Enum.SurfaceType documentation by either rephrasing some text, or adding some deprecation tags to defunct/discontinued items. The following changes are:

- Changing the word "side" to "surface" to refer to the specific surface (or surfaces) being used.

- Changing the phrasing to be read as past-tense.

- Adding a Deprecation message to Enum.SurfaceType itself as its original functionallity has been discontinued and has been largely replaced by newer methods.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
https://devforum.roblox.com/t/1222218

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
