### PR TITLE
Update PolicyService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/PolicyService.yaml
+++ b/content/en-us/reference/engine/classes/PolicyService.yaml
@@ -49,7 +49,7 @@ methods:
       <td>ArePaidRandomItemsRestricted</td>
       <td>Boolean</td>
       <td>Any experience that has paid random items</td>
-      <td>When true, the player cannot interact with paid (via in-experience currency or Robux) random item generators.</td>
+      <td>When true, the player cannot interact with paid (via in-experience currency bought with Robux, or Robux directly) random item generators.</td>
       </tr>
       <tr>
       <td>AllowedExternalLinkReferences</td>


### PR DESCRIPTION
Clarify the ArePaidRandomItemsRestricted policy.

## Changes

<!-- Please summarize your changes. -->
I have edited the PolicyService wiki page to clarify that the `ArePaidRandomItemsRestricted` field specifically refers to in-experience currency that was bought with Robux; as otherwise, it implies that *any* currency which can be used to trade for virtual items is not permitted unless the policy is true.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
https://create.roblox.com/docs/production/monetization/randomized-virtual-items-policy

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
