### PR TITLE
Update Documentation for AudioFilter

### DIFF
--- a/content/en-us/reference/engine/classes/AudioFilter.yaml
+++ b/content/en-us/reference/engine/classes/AudioFilter.yaml
@@ -105,7 +105,7 @@ properties:
       For `Class.AudioFilter|FilterType` values of
       `Enum.AudioFilterType.Lowpass12dB|Lowpass12dB` and
       `Enum.AudioFilterType.Highpass12dB|Highpass12dB`, a **Q** value of
-      `sqrt(2)`, or `0.707`, corresponds to a flat filter at a 12dB/octave
+      `sqrt(2) / 2`, or `0.707`, corresponds to a flat filter at a 12dB/octave
       slope.
     code_samples: []
     type: float


### PR DESCRIPTION
## Changes

The AudioFilter documentation states that a Q value of "sqrt(2), or 0.707 is flat" – but this 0.707 is sqrt(2) / 2

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
