### PR TITLE
Update StudioService.yaml (code example ActiveScript)

### DIFF
--- a/content/en-us/reference/engine/classes/StudioService.yaml
+++ b/content/en-us/reference/engine/classes/StudioService.yaml
@@ -44,8 +44,10 @@ properties:
       ```lua
       local startTime = os.time()
       local activeScript
-      local function onActiveScriptChanged(newActiveScript)
-      	if newActiveScript ~= activeScript then
+      local function onActiveScriptChanged()
+        local newActiveScript = game:GetService("StudioService").ActiveScript
+      
+      	if newActiveScript ~= activeScript and activeScript then
       		local deltaTime = os.time() - startTime
       		print(("You edited %s for %d:%2.d"):format(activeScript.Name, deltaTime // 60, deltaTime % 60))
       	end

--- a/content/en-us/reference/engine/classes/StudioService.yaml
+++ b/content/en-us/reference/engine/classes/StudioService.yaml
@@ -42,10 +42,12 @@ properties:
       measure for how long a script was active.
 
       ```lua
+      local StudioService = game:GetService("StudioService")
+      
       local startTime = os.time()
       local activeScript
       local function onActiveScriptChanged()
-        local newActiveScript = game:GetService("StudioService").ActiveScript
+        local newActiveScript = StudioService.ActiveScript
       
       	if newActiveScript ~= activeScript and activeScript then
       		local deltaTime = os.time() - startTime
@@ -54,7 +56,8 @@ properties:
       	startTime = os.time()
       	activeScript = newActiveScript
       end
-      game:GetService("StudioService"):GetPropertyChangedSignal("ActiveScript"):Connect(onActiveScriptChanged)
+      
+      StudioService:GetPropertyChangedSignal("ActiveScript"):Connect(onActiveScriptChanged)
       ```
     code_samples:
     type: Instance

--- a/content/en-us/reference/engine/classes/StudioService.yaml
+++ b/content/en-us/reference/engine/classes/StudioService.yaml
@@ -49,7 +49,7 @@ properties:
       local function onActiveScriptChanged()
         local newActiveScript = StudioService.ActiveScript
       
-      	if newActiveScript ~= activeScript and activeScript then
+      	if activeScript and newActiveScript ~= activeScript then
       		local deltaTime = os.time() - startTime
       		print(("You edited %s for %d:%2.d"):format(activeScript.Name, deltaTime // 60, deltaTime % 60))
       	end


### PR DESCRIPTION
Previously, newActiveScript was used as a parameter, but GetPropertyChangedSignal does not accept parameters. As a result, newActiveScript was always nil, causing the script to fail. I have made newActiveScript a variable and I also added an existence check for ActiveScript.