### PR TITLE
Minor typo in data-store-api-handling.md

### DIFF
--- a/content/en-us/cloud/open-cloud/data-store-api-handling.md
+++ b/content/en-us/cloud/open-cloud/data-store-api-handling.md
@@ -112,7 +112,7 @@ Unlike the Lua API, these limits currently do not scale based on user counts. Ex
 Before sending your request, make sure to validate endpoint parameters on formatting requirements and constraints based on the following table. Individual endpoints can have additional requirements beyond these. If a parameter doesn't satisfy the following restrictions, the endpoint returns a `400 Bad Request`.
 
 <Alert severity="info">
-Ordered Data Stores endpoints use [Perfect-Encoding](https://www.rfc-editor.org/rfc/rfc3986#section-2.1) for all query and body parameters. Unless you have special characters in your parameter values that break URLs, you don't need to handle encoding yourself.
+Ordered Data Stores endpoints use [Percent-Encoding](https://www.rfc-editor.org/rfc/rfc3986#section-2.1) for all query and body parameters. Unless you have special characters in your parameter values that break URLs, you don't need to handle encoding yourself.
 </Alert>
 
 <table>


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

The original alert info for the Input Validation section said "Perfect-Encoding", while the linked header is "Percent-Encoding". The commit changes "Perfect" into "Percent".

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
