### PR TITLE
Use DataStore instead of GlobalDataStore in reference

### DIFF
--- a/content/en-us/cloud/open-cloud/usage-data-stores.md
+++ b/content/en-us/cloud/open-cloud/usage-data-stores.md
@@ -27,7 +27,7 @@ Although Open Cloud APIs are similar to the Lua `Class.DataStoreService`, there 
 
 - **Universe ID and data store name**: Unlike the Lua API, Open Cloud APIs are stateless and can come from anywhere, so you need to always provide the **Universe ID**, the unique identifier of your experience, and the data store **name** when sending the requests. For more information on how to get a Universe ID, see [Universe ID](../../cloud/open-cloud/data-store-api-handling.md#universe-id).
 
-- **Separate permissions for creating and updating**: The Lua API creates new entries if they don't exist when you call `Class.GlobalDataStore:SetAsync()`, but Open Cloud methods for creating and updating entries are separate. Separate permissions can be safer and more flexible in certain situations. For example, you can create a customer support tool that can edit an existing user's profile but can't create a new user's profile.
+- **Separate permissions for creating and updating**: The Lua API creates new entries if they don't exist when you call `Class.DataStore:SetAsync()`, but Open Cloud methods for creating and updating entries are separate. Separate permissions can be safer and more flexible in certain situations. For example, you can create a customer support tool that can edit an existing user's profile but can't create a new user's profile.
 
 - **Data serialization**: All Open Cloud endpoints require you to serialize all data before network transportation. Serialization means to convert an object into that string, and deserialization is its inverse operation (convert a string to an object). The Lua API serializes and deserializes entry content automatically, but for Open Cloud you need to generate or parse your entry data with JSON on your own.
 


### PR DESCRIPTION
## Changes

In Data Stores reference, use `class.DataStore` instead of `class.GlobalDataStore`. 

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
