### PR TITLE
Fix `os.clock` description

### DIFF
--- a/content/en-us/reference/engine/libraries/os.yaml
+++ b/content/en-us/reference/engine/libraries/os.yaml
@@ -300,10 +300,10 @@ functions:
     code_samples:
   - name: os.clock
     summary: |
-      Returns a high-precision amount of CPU time used by Lua in seconds,
+      Returns a high-precision amount of elapsed CPU time in seconds,
       intended for use in benchmarking.
     description: |
-      Returns the amount of CPU time used by Lua in seconds. This value has high
+      Returns the amount of elapsed CPU time in seconds. This value has high
       precision, about 1 microsecond, and is intended for use in benchmarking.
 
       ```lua


### PR DESCRIPTION
"time used by Luau" is not correct.

https://github.com/luau-lang/luau/blob/ce8495a69e7a4e774a5402f99e1fc282a92ced91/VM/src/lperf.cpp#L57