### PR TITLE
Fix typo: "Lasers Beams" -> "Laser Beams"

### DIFF
--- a/content/en-us/tutorials/building/effects/laser-traps-with-beams.md
+++ b/content/en-us/tutorials/building/effects/laser-traps-with-beams.md
@@ -1,5 +1,5 @@
 ---
-title: Creating Lasers Beams
+title: Creating Laser Beams
 description: A tutorial on creating a laser beam that sets an avatar's health to 0 on impact.
 ---
 


### PR DESCRIPTION
Simply fixing the typo "Lasers Beams" such that it says "Laser Beams"