### PR TITLE
Fix Enum.ReverbType item descriptions

### DIFF
--- a/content/en-us/reference/engine/enums/ReverbType.yaml
+++ b/content/en-us/reference/engine/enums/ReverbType.yaml
@@ -152,7 +152,7 @@ items:
     deprecation_message: ''
   - name: UnderWater
     summary: |
-      Sound reverb is changed to sound like the player is under water.
+      Sound reverb is changed to sound like the player is underwater.
     value: 23
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/ReverbType.yaml
+++ b/content/en-us/reference/engine/enums/ReverbType.yaml
@@ -98,7 +98,7 @@ items:
     deprecation_message: ''
   - name: StoneCorridor
     summary: |
-      Sound reverb is changed to sound like the player is a stone corridor.
+      Sound reverb is changed to sound like the player is in a stone corridor.
     value: 14
     tags: []
     deprecation_message: ''
@@ -116,7 +116,7 @@ items:
     deprecation_message: ''
   - name: City
     summary: |
-      Sound reverb is changed to sound like the player is in city.
+      Sound reverb is changed to sound like the player is in a city.
     value: 17
     tags: []
     deprecation_message: ''
@@ -152,7 +152,7 @@ items:
     deprecation_message: ''
   - name: UnderWater
     summary: |
-      Sound reverb makes it sound like the player is under water.
+      Sound reverb is changed to sound like the player is under water.
     value: 23
     tags: []
     deprecation_message: ''


### PR DESCRIPTION
## Changes

Fixed grammar mistakes in the descriptions of `City` and `StoneCorridor`.
The description of `UnderWater` was also changed to be consistent with the others.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
