### PR TITLE
Fix Model:GetBoundingBox() return type

### DIFF
--- a/content/en-us/reference/engine/classes/Model.yaml
+++ b/content/en-us/reference/engine/classes/Model.yaml
@@ -304,10 +304,12 @@ methods:
     code_samples:
     parameters: []
     returns:
-      - type: void
+      - type: CFrame
         summary: |
-          A `Datatype.CFrame` representing the orientation of the volume
-          followed by a `Datatype.Vector3` representing the size of the volume.
+          The center of the bounding box.
+      - type: Vector3
+        summary: |
+          The size of the bounding box.
     tags: []
     deprecation_message: ''
     security: None


### PR DESCRIPTION
## Changes

Show the correct return types for `Model:GetBoundingBox()` instead of just `void`.

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
