### PR TITLE
Fix `Model:GetBoundingBox` return type

### DIFF
--- a/content/en-us/reference/engine/classes/Model.yaml
+++ b/content/en-us/reference/engine/classes/Model.yaml
@@ -306,10 +306,10 @@ methods:
     returns:
       - type: CFrame
         summary: |
-          Center of the volume that contains all `Class.BasePart` children.
+          Center of the volume.
       - type: Vector3
         summary: |
-          Size of the volume that contains all `Class.BasePart` children.
+          Size of the volume.
     tags: []
     deprecation_message: ''
     security: None

--- a/content/en-us/reference/engine/classes/Model.yaml
+++ b/content/en-us/reference/engine/classes/Model.yaml
@@ -306,7 +306,7 @@ methods:
     returns:
       - type: CFrame
         summary: |
-          Orientation of the volume that contains all `Class.BasePart` children.
+          Center of the volume that contains all `Class.BasePart` children.
       - type: Vector3
         summary: |
           Size of the volume that contains all `Class.BasePart` children.

--- a/content/en-us/reference/engine/classes/Model.yaml
+++ b/content/en-us/reference/engine/classes/Model.yaml
@@ -304,10 +304,12 @@ methods:
     code_samples:
     parameters: []
     returns:
-      - type: void
+      - type: CFrame
         summary: |
-          A `Datatype.CFrame` representing the orientation of the volume
-          followed by a `Datatype.Vector3` representing the size of the volume.
+          Orientation of the volume that contains all `Class.BasePart` children.
+      - type: Vector3
+        summary: |
+          Size of the volume that contains all `Class.BasePart` children.
     tags: []
     deprecation_message: ''
     security: None


### PR DESCRIPTION
## Changes
It doesn't return `void`.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
