### PR TITLE
Update TeleportService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/TeleportService.yaml
+++ b/content/en-us/reference/engine/classes/TeleportService.yaml
@@ -1031,12 +1031,12 @@ methods:
         default: nil
         summary: |
           An optional `Class.TeleportOptions` object containing additional
-          arguments to the TeleportAsync call.
+          arguments to the TeleportAsync call. If this is not passed, no result will be returned.
     returns:
       - type: Instance
         summary: |
           A `Class.TeleportAsyncResult` object that provides information about
-          the final teleport destination.
+          the final teleport destination. If no `Class.TeleportOptions` parameter is passed, no result will be returned.
     tags:
       - Yields
     deprecation_message: ''


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
The API documentation here acts as if TeleportAsyncResult will always be returned. It does not notify of the result that users may experience if TeleportOptions is not passed. As such, it should be denoted as an optional parameter and the result marked as an optional result.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
See: https://devforum.roblox.com/t/teleportasync-not-returning-a-teleportasyncresult/3145215/13

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
