### PR TITLE
 Remove broken and deprecated reference to DebuggerManager

### DIFF
--- a/content/en-us/reference/engine/globals/RobloxGlobals.yaml
+++ b/content/en-us/reference/engine/globals/RobloxGlobals.yaml
@@ -114,17 +114,23 @@ functions:
     code_samples:
   - name: DebuggerManager
     summary: |
-      Refers to the DebuggerManager, which acts as an interface for the Lua
-      debugger feature.
+      Refers to the legacy DebuggerManager, which acts as an interface for
+      the Luau debugger feature.
     description: |
-      Returns the `Class.DebuggerManager` class, which acts as an interface for
-      Roblox's Lua debugger feature.
+      Returns the legacy `DebuggerManager` class, which acts as an interface
+      for Roblox's Luau debugger feature.
+
+      This function is not recognised by Luau's analysis tool and will raise
+      an undefined global warning.
     parameters:
     returns:
       - type: DebuggerManager
         summary: ''
     tags:
       - Deprecated
+    deprecation_message: |
+      The `DebuggerManager` is obsolete and serves little to no usecase to
+      developers.
     code_samples:
   - name: elapsedTime
     summary: |

--- a/content/en-us/reference/engine/globals/RobloxGlobals.yaml
+++ b/content/en-us/reference/engine/globals/RobloxGlobals.yaml
@@ -114,13 +114,13 @@ functions:
     code_samples:
   - name: DebuggerManager
     summary: |
-      Refers to the legacy DebuggerManager, which acts as an interface for
+      Refers to the legacy `DebuggerManager` class which acts as an interface for
       the Luau debugger feature.
     description: |
-      Returns the legacy `DebuggerManager` class, which acts as an interface
+      Returns the legacy `DebuggerManager` class which acts as an interface
       for Roblox's Luau debugger feature.
 
-      This function is not recognised by Luau's analysis tool and will raise
+      This function is not recognized by Luau's analysis tool and will raise
       an undefined global warning.
     parameters:
     returns:
@@ -129,7 +129,7 @@ functions:
     tags:
       - Deprecated
     deprecation_message: |
-      The `DebuggerManager` is obsolete and serves little to no usecase to
+      The `DebuggerManager` is obsolete and serves little to no use case for
       developers.
     code_samples:
   - name: elapsedTime

--- a/content/en-us/reference/engine/libraries/debug.yaml
+++ b/content/en-us/reference/engine/libraries/debug.yaml
@@ -5,8 +5,7 @@ summary: |
 description: |
   Provides a few basic functions for debugging code in Roblox. Unlike the
   `Library.debug` library found in Lua natively, this version has been heavily
-  sandboxed. Roblox does, however, have debugging functionality similar to Lua's
-  native debugging functionality (see the `Class.DebuggerManager` class).
+  sandboxed.
 code_samples:
 properties:
 functions:


### PR DESCRIPTION
## Changes

Removes a broken reference to the deprecated and mostly obsolete DebuggerManager.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
