### PR TITLE
Correct RBXScriptSignal grammar

### DIFF
--- a/content/en-us/reference/engine/datatypes/RBXScriptSignal.yaml
+++ b/content/en-us/reference/engine/datatypes/RBXScriptSignal.yaml
@@ -21,7 +21,7 @@ methods:
       Connects the given function to the event and returns an
       `Datatype.RBXScriptConnection` that represents it.
     description: |
-      Establishes a function to be called when the event fires. Returns a
+      Establishes a function to be called when the event fires. Returns an
       `Datatype.RBXScriptConnection` object associated with the connection.
     parameters:
       - name: func
@@ -39,7 +39,7 @@ methods:
       Connects the given function to the event and returns an
       `Datatype.RBXScriptConnection` that represents it.
     description: |
-      Establishes a function to be called when the event fires. Returns a
+      Establishes a function to be called when the event fires. Returns an
       `Datatype.RBXScriptConnection` object associated with the connection. When
       the event fires, the signal callback is executed in a desynchronized
       state. Using `ConnectParallel` is similar to, but more efficient than,
@@ -63,7 +63,7 @@ methods:
       Connects the given function to the event (for a single invocation) and
       returns an `Datatype.RBXScriptConnection` that represents it.
     description: |
-      Establishes a function to be called when the event fires. Returns a
+      Establishes a function to be called when the event fires. Returns an
       `Datatype.RBXScriptConnection` object associated with the connection. The
       behavior of `Once` is similar to `Connect`. However, instead of allowing
       multiple events to be received by the specified function, only the first


### PR DESCRIPTION
## Changes
Corrects a `RBXScriptSignal` to an `RBXScriptSignal`

This is consistent with the summaries for RBXScriptSignal properties.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
