### PR TITLE
Move gcinfo() to Lua Globals

### DIFF
--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -64,7 +64,7 @@ functions:
       Roblox's Lua sandbox only allows the `count` option to be used (the total
       memory in use by Lua, in kilobytes), as other options can interfere with
       existing processes. Effectively, this makes
-      `Global.RobloxGlobals.gcinfo()` a superior alternative that should be used
+      `Global.LuaGlobals.gcinfo()` a superior alternative that should be used
       instead.
     parameters:
       - name: operation
@@ -78,6 +78,19 @@ functions:
         summary: ''
     tags:
       - Deprecated
+    code_samples:
+  - name: gcinfo
+    summary: |
+      Returns the total memory heap size in kilobytes.
+    description: |
+      Returns the total memory heap size in kilobytes. The number reflects the
+      current heap consumption from the operating system perspective, which
+      fluctuates over time as garbage collector frees objects.
+    parameters:
+    returns:
+      - type: number
+        summary: ''
+    tags:
     code_samples:
   - name: error
     summary: |

--- a/content/en-us/reference/engine/globals/RobloxGlobals.yaml
+++ b/content/en-us/reference/engine/globals/RobloxGlobals.yaml
@@ -146,19 +146,6 @@ functions:
         summary: ''
     tags:
     code_samples:
-  - name: gcinfo
-    summary: |
-      Returns the total memory heap size in kilobytes.
-    description: |
-      Returns the total memory heap size in kilobytes. The number reflects the
-      current heap consumption from the operating system perspective, which
-      fluctuates over time as garbage collector frees objects.
-    parameters:
-    returns:
-      - type: number
-        summary: ''
-    tags:
-    code_samples:
   - name: PluginManager
     summary: |
       Refers to the PluginManager, a deprecated singleton that was previously


### PR DESCRIPTION
## Changes

Moving `gcinfo()` in the engine reference from the `RobloxGlobals` page to the `LuaGlobals` page, as it is part of Lua 5.1

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
