### PR TITLE
Pathfinding patch

### DIFF
--- a/content/en-us/characters/pathfinding.md
+++ b/content/en-us/characters/pathfinding.md
@@ -187,8 +187,8 @@ local function followPath(destination)
                 end
 
                 if reached and nextWaypointIndex < #waypoints then
-                    currentWaypointPlaneNormal = (waypoints[nextWaypointIndex].Position - waypoints[nextWaypointIndex + 1].Position).Unit
-                    currentWaypointPlaneDistance = currentWaypointPlaneNormal:Dot(waypoints[nextWaypointIndex + 1].Position)
+                    currentWaypointPlaneNormal = ZERO_VECTOR3
+                    currentWaypointPlaneDistance = 0
                     -- Increase waypoint index and move to next waypoint
                     nextWaypointIndex += 1
                     humanoid:MoveTo(waypoints[nextWaypointIndex].Position)
@@ -356,8 +356,8 @@ local function followPath(destination)
                 end
 
                 if reached and nextWaypointIndex < #waypoints then
-                    currentWaypointPlaneNormal = (waypoints[nextWaypointIndex].Position - waypoints[nextWaypointIndex + 1].Position).Unit
-                    currentWaypointPlaneDistance = currentWaypointPlaneNormal:Dot(waypoints[nextWaypointIndex + 1].Position)
+                    currentWaypointPlaneNormal = ZERO_VECTOR3
+                    currentWaypointPlaneDistance = 0
                     -- Increase waypoint index and move to next waypoint
                     nextWaypointIndex += 1
                     humanoid:MoveTo(waypoints[nextWaypointIndex].Position)
@@ -623,8 +623,8 @@ To create a `Class.PathfindingLink` using this example:
 										end
 
 										if reached and nextWaypointIndex < #waypoints then
-												currentWaypointPlaneNormal = (waypoints[nextWaypointIndex].Position - waypoints[nextWaypointIndex + 1].Position).Unit
-												currentWaypointPlaneDistance = currentWaypointPlaneNormal:Dot(waypoints[nextWaypointIndex + 1].Position)
+												currentWaypointPlaneNormal = ZERO_VECTOR3
+                                                currentWaypointPlaneDistance = 0
 												-- Increase waypoint index and move to next waypoint
 												nextWaypointIndex += 1
 												-- Use boat if waypoint label is "UseBoat"; otherwise move to next waypoint


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
When we call Humanoid:MoveTo() from waypoint to waypoint, and use the MoveToFinished event to detect when the character reaches each waypoint it does work. However unlike the demo place and code portrayed in the documentation on Character Pathfinding, many games will not operate with smoothness due to the event having a delay on being communicated, leaving a stuttering NPC between nodes and overall a poor visual effect.

This is detrimental on considering performance in public games, unlike test baseplates with minimal events and memory.

To resolve this issue, I implemented a snippet of ClickToMoveController under Player > PlayerScripts > PlayerModule > ControlModule. 

You should notice that ClickToMove controller does not register for MoveToFinished but instead uses its own logic to decide when to move to next waypoint - namely the RunService.RenderStepped event. This would avoid waiting for the delayed event.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
https://devforum.roblox.com/t/npc-moveto-has-a-stuttering-effect-whilst-using-pathfindingservice/3067241?u=m_etrics

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
