### PR TITLE
Fix punctuation in ForceLimitMode.yaml

### DIFF
--- a/content/en-us/reference/engine/enums/ForceLimitMode.yaml
+++ b/content/en-us/reference/engine/enums/ForceLimitMode.yaml
@@ -2,8 +2,7 @@ name: ForceLimitMode
 type: enum
 summary: |
   The **ForceLimitMode** enum determines how the maximum force for a constraint
-  is specified and how that limit is enforced by the constraint.  
-  .
+  is specified and how that limit is enforced by the constraint.
 description: |
   This enum is used to determine how the maximum force for a constraint is
   specified and how that limit will be enforced by the constraint.


### PR DESCRIPTION
## Changes

Removed the additional whitespaces and the dot. This isn't visible on the website, however, I found it while using the Luau Language Server:

![image](https://github.com/user-attachments/assets/ef3b4af3-81af-40da-b32b-caedc05ef03a)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
