### PR TITLE
add descriptions for SpectrumEnabled, Bypass, and GetConnectedWires

### DIFF
--- a/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
+++ b/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
@@ -58,8 +58,13 @@ properties:
       can_load: false
       can_save: true
   - name: AudioAnalyzer.SpectrumEnabled
-    summary: ''
-    description: ''
+    summary: 'Enables usage of `Class.AudioAnalyzer:GetSpectrum|GetSpectrum`'
+    description: |
+        Enables usage of `Class.AudioAnalyzer:GetSpectrum|GetSpectrum`.
+        If false, `Class.AudioAnalyzer:GetSpectrum|GetSpectrum` returns an empty array,
+        but the CPU overhead of this `Class.AudioAnalyzer` is dramatically reduced.
+        So, if you are only analyzing the *volume* of an audio stream,
+        this can be disabled to improve performance.
     code_samples: []
     type: bool
     tags: []
@@ -74,8 +79,10 @@ properties:
       can_save: true
 methods:
   - name: AudioAnalyzer:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioAnalyzer` has one "Input" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
+++ b/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
@@ -63,7 +63,7 @@ properties:
         Enables usage of `Class.AudioAnalyzer:GetSpectrum|GetSpectrum`.
         If false, `Class.AudioAnalyzer:GetSpectrum|GetSpectrum` returns an empty array,
         but the CPU overhead of this `Class.AudioAnalyzer` is dramatically reduced.
-        So, if you are only analyzing the *volume* of an audio stream,
+        This means that if you are only analyzing the **volume** of an audio stream,
         this can be disabled to improve performance.
     code_samples: []
     type: bool

--- a/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
+++ b/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
@@ -62,7 +62,7 @@ properties:
     description: |
         Enables usage of `Class.AudioAnalyzer:GetSpectrum|GetSpectrum`.
         If false, `Class.AudioAnalyzer:GetSpectrum|GetSpectrum` returns an empty array,
-        but the CPU overhead of this `Class.AudioAnalyzer` is dramatically reduced.
+        but the CPU overhead of the `Class.AudioAnalyzer` is dramatically reduced.
         This means that if you are only analyzing the **volume** of an audio stream,
         this can be disabled to improve performance.
     code_samples: []

--- a/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
+++ b/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
@@ -79,7 +79,7 @@ properties:
       can_save: true
 methods:
   - name: AudioAnalyzer:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioAnalyzer` has one "Input" pin.

--- a/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
+++ b/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
@@ -58,7 +58,7 @@ properties:
       can_load: false
       can_save: true
   - name: AudioAnalyzer.SpectrumEnabled
-    summary: 'Enables usage of `Class.AudioAnalyzer:GetSpectrum|GetSpectrum`'
+    summary: 'Enables usage of `Class.AudioAnalyzer:GetSpectrum|GetSpectrum`.'
     description: |
         Enables usage of `Class.AudioAnalyzer:GetSpectrum|GetSpectrum`.
         If false, `Class.AudioAnalyzer:GetSpectrum|GetSpectrum` returns an empty array,

--- a/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
+++ b/content/en-us/reference/engine/classes/AudioAnalyzer.yaml
@@ -64,7 +64,7 @@ properties:
         If false, `Class.AudioAnalyzer:GetSpectrum|GetSpectrum` returns an empty array,
         but the CPU overhead of the `Class.AudioAnalyzer` is dramatically reduced.
         This means that if you are only analyzing the **volume** of an audio stream,
-        this can be disabled to improve performance.
+        you can disable this property to improve performance.
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/AudioChorus.yaml
+++ b/content/en-us/reference/engine/classes/AudioChorus.yaml
@@ -22,7 +22,7 @@ deprecation_message: ''
 properties:
   - name: AudioChorus.Bypass
     summary: 'If true, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/AudioChorus.yaml
+++ b/content/en-us/reference/engine/classes/AudioChorus.yaml
@@ -21,7 +21,7 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioChorus.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
     description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool

--- a/content/en-us/reference/engine/classes/AudioChorus.yaml
+++ b/content/en-us/reference/engine/classes/AudioChorus.yaml
@@ -93,7 +93,7 @@ properties:
       can_save: true
 methods:
   - name: AudioChorus:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioChorus` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioChorus.yaml
+++ b/content/en-us/reference/engine/classes/AudioChorus.yaml
@@ -21,8 +21,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioChorus.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -93,8 +93,10 @@ properties:
       can_save: true
 methods:
   - name: AudioChorus:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioChorus` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioCompressor.yaml
+++ b/content/en-us/reference/engine/classes/AudioCompressor.yaml
@@ -40,8 +40,8 @@ properties:
       can_load: true
       can_save: true
   - name: AudioCompressor.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -144,8 +144,10 @@ properties:
       can_save: true
 methods:
   - name: AudioCompressor:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioCompressor` has one "Input" pin, one "Sidechain" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioCompressor.yaml
+++ b/content/en-us/reference/engine/classes/AudioCompressor.yaml
@@ -144,7 +144,7 @@ properties:
       can_save: true
 methods:
   - name: AudioCompressor:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioCompressor` has one "Input" pin, one "Sidechain" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioCompressor.yaml
+++ b/content/en-us/reference/engine/classes/AudioCompressor.yaml
@@ -41,7 +41,7 @@ properties:
       can_save: true
   - name: AudioCompressor.Bypass
     summary: 'If true, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/AudioCompressor.yaml
+++ b/content/en-us/reference/engine/classes/AudioCompressor.yaml
@@ -40,7 +40,7 @@ properties:
       can_load: true
       can_save: true
   - name: AudioCompressor.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
     description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool

--- a/content/en-us/reference/engine/classes/AudioDeviceInput.yaml
+++ b/content/en-us/reference/engine/classes/AudioDeviceInput.yaml
@@ -168,7 +168,7 @@ properties:
       can_save: true
 methods:
   - name: AudioDeviceInput:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioDeviceInput` has one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioDeviceInput.yaml
+++ b/content/en-us/reference/engine/classes/AudioDeviceInput.yaml
@@ -168,8 +168,10 @@ properties:
       can_save: true
 methods:
   - name: AudioDeviceInput:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioDeviceInput` has one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioDeviceOutput.yaml
+++ b/content/en-us/reference/engine/classes/AudioDeviceOutput.yaml
@@ -38,8 +38,10 @@ properties:
       can_save: true
 methods:
   - name: AudioDeviceOutput:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioDeviceOutput` has one "Input" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioDeviceOutput.yaml
+++ b/content/en-us/reference/engine/classes/AudioDeviceOutput.yaml
@@ -38,7 +38,7 @@ properties:
       can_save: true
 methods:
   - name: AudioDeviceOutput:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioDeviceOutput` has one "Input" pin.

--- a/content/en-us/reference/engine/classes/AudioDistortion.yaml
+++ b/content/en-us/reference/engine/classes/AudioDistortion.yaml
@@ -15,8 +15,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioDistortion.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -48,7 +48,7 @@ properties:
       can_save: true
 methods:
   - name: AudioDistortion:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioDistortion` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioDistortion.yaml
+++ b/content/en-us/reference/engine/classes/AudioDistortion.yaml
@@ -15,8 +15,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioDistortion.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -48,8 +48,10 @@ properties:
       can_save: true
 methods:
   - name: AudioDistortion:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioDistortion` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioEcho.yaml
+++ b/content/en-us/reference/engine/classes/AudioEcho.yaml
@@ -15,8 +15,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioEcho.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -104,8 +104,10 @@ properties:
       can_save: true
 methods:
   - name: AudioEcho:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioEcho` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioEcho.yaml
+++ b/content/en-us/reference/engine/classes/AudioEcho.yaml
@@ -15,8 +15,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioEcho.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -104,7 +104,7 @@ properties:
       can_save: true
 methods:
   - name: AudioEcho:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioEcho` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioEmitter.yaml
+++ b/content/en-us/reference/engine/classes/AudioEmitter.yaml
@@ -69,7 +69,7 @@ properties:
       can_save: true
 methods:
   - name: AudioEmitter:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioEmitter` has one "Input" pin.

--- a/content/en-us/reference/engine/classes/AudioEmitter.yaml
+++ b/content/en-us/reference/engine/classes/AudioEmitter.yaml
@@ -69,8 +69,10 @@ properties:
       can_save: true
 methods:
   - name: AudioEmitter:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioEmitter` has one "Input" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioEqualizer.yaml
+++ b/content/en-us/reference/engine/classes/AudioEqualizer.yaml
@@ -18,8 +18,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioEqualizer.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -129,7 +129,7 @@ properties:
       can_save: true
 methods:
   - name: AudioEqualizer:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioEqualizer` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioEqualizer.yaml
+++ b/content/en-us/reference/engine/classes/AudioEqualizer.yaml
@@ -18,8 +18,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioEqualizer.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -129,8 +129,10 @@ properties:
       can_save: true
 methods:
   - name: AudioEqualizer:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioEqualizer` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioFader.yaml
+++ b/content/en-us/reference/engine/classes/AudioFader.yaml
@@ -15,8 +15,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioFader.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -49,8 +49,10 @@ properties:
       can_save: true
 methods:
   - name: AudioFader:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioFader` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioFader.yaml
+++ b/content/en-us/reference/engine/classes/AudioFader.yaml
@@ -15,8 +15,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioFader.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -49,7 +49,7 @@ properties:
       can_save: true
 methods:
   - name: AudioFader:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioFader` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioFilter.yaml
+++ b/content/en-us/reference/engine/classes/AudioFilter.yaml
@@ -19,8 +19,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioFilter.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -136,8 +136,10 @@ properties:
       can_save: true
 methods:
   - name: AudioFilter:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioFilter` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioFilter.yaml
+++ b/content/en-us/reference/engine/classes/AudioFilter.yaml
@@ -19,8 +19,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioFilter.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -136,7 +136,7 @@ properties:
       can_save: true
 methods:
   - name: AudioFilter:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioFilter` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioFlanger.yaml
+++ b/content/en-us/reference/engine/classes/AudioFlanger.yaml
@@ -16,8 +16,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioFlanger.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -88,8 +88,10 @@ properties:
       can_save: true
 methods:
   - name: AudioFlanger:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioFlanger` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioFlanger.yaml
+++ b/content/en-us/reference/engine/classes/AudioFlanger.yaml
@@ -16,8 +16,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioFlanger.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -88,7 +88,7 @@ properties:
       can_save: true
 methods:
   - name: AudioFlanger:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioFlanger` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioListener.yaml
+++ b/content/en-us/reference/engine/classes/AudioListener.yaml
@@ -68,7 +68,7 @@ properties:
       can_save: true
 methods:
   - name: AudioListener:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioListener` has one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioListener.yaml
+++ b/content/en-us/reference/engine/classes/AudioListener.yaml
@@ -68,8 +68,10 @@ properties:
       can_save: true
 methods:
   - name: AudioListener:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioListener` has one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioPitchShifter.yaml
+++ b/content/en-us/reference/engine/classes/AudioPitchShifter.yaml
@@ -17,8 +17,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioPitchShifter.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -51,8 +51,10 @@ properties:
       can_save: true
 methods:
   - name: AudioPitchShifter:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioPitchShifter` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioPitchShifter.yaml
+++ b/content/en-us/reference/engine/classes/AudioPitchShifter.yaml
@@ -17,8 +17,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioPitchShifter.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/AudioPitchShifter.yaml
+++ b/content/en-us/reference/engine/classes/AudioPitchShifter.yaml
@@ -51,7 +51,7 @@ properties:
       can_save: true
 methods:
   - name: AudioPitchShifter:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioPitchShifter` has one "Input" pin, and one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioPlayer.yaml
+++ b/content/en-us/reference/engine/classes/AudioPlayer.yaml
@@ -275,7 +275,7 @@ properties:
       can_save: true
 methods:
   - name: AudioPlayer:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioPlayer` has one "Output" pin.

--- a/content/en-us/reference/engine/classes/AudioPlayer.yaml
+++ b/content/en-us/reference/engine/classes/AudioPlayer.yaml
@@ -275,8 +275,10 @@ properties:
       can_save: true
 methods:
   - name: AudioPlayer:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioPlayer` has one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioReverb.yaml
+++ b/content/en-us/reference/engine/classes/AudioReverb.yaml
@@ -15,8 +15,8 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioReverb.Bypass
-    summary: ''
-    description: ''
+    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []
@@ -255,8 +255,10 @@ properties:
       can_save: true
 methods:
   - name: AudioReverb:GetConnectedWires
-    summary: ''
-    description: ''
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    description: |
+        Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
+        `Class.AudioReverb` has one "Input" pin, and one "Output" pin.
     code_samples: []
     parameters:
       - name: pin

--- a/content/en-us/reference/engine/classes/AudioReverb.yaml
+++ b/content/en-us/reference/engine/classes/AudioReverb.yaml
@@ -16,7 +16,7 @@ deprecation_message: ''
 properties:
   - name: AudioReverb.Bypass
     summary: 'If true, audio streams are passed-through unaffected by this effect.'
-    description: 'If True, audio streams are passed-through unaffected by this effect.'
+    description: 'If true, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/AudioReverb.yaml
+++ b/content/en-us/reference/engine/classes/AudioReverb.yaml
@@ -15,7 +15,7 @@ tags: []
 deprecation_message: ''
 properties:
   - name: AudioReverb.Bypass
-    summary: 'If True, audio streams are passed-through unaffected by this effect.'
+    summary: 'If true, audio streams are passed-through unaffected by this effect.'
     description: 'If True, audio streams are passed-through unaffected by this effect.'
     code_samples: []
     type: bool

--- a/content/en-us/reference/engine/classes/AudioReverb.yaml
+++ b/content/en-us/reference/engine/classes/AudioReverb.yaml
@@ -255,7 +255,7 @@ properties:
       can_save: true
 methods:
   - name: AudioReverb:GetConnectedWires
-    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin'
+    summary: 'Returns an array of `Class.Wire|Wires` that are connected to the specified pin.'
     description: |
         Returns an array of `Class.Wire|Wires` that are connected to the specified pin.
         `Class.AudioReverb` has one "Input" pin, and one "Output" pin.


### PR DESCRIPTION
## Changes

add descriptions for `AudioAnalyzer.SpectrumEnabled`, `Audio*.Bypass`, and `Audio*:GetConnectedWires`

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
