### PR TITLE
Update creating-basic-heads.md mapping instructions

### DIFF
--- a/content/en-us/art/characters/facial-animation/creating-basic-heads.md
+++ b/content/en-us/art/characters/facial-animation/creating-basic-heads.md
@@ -419,7 +419,7 @@ To map your saved poses and the RootFaceJoint:
 
 5. Click the **Type** dropdown, then select **String**.
 6. In the **Property Name** field:
-   1. If you are mapping a pose, input the **frame number** you are mapping.
+   1. If you are mapping a pose, input the **frame number** you are mapping, **Frame0** for example.
    2. If you are mapping the RootFaceJoint, input **RootFaceJoint**.
 7. Leave the **Default Value** and **Description** fields empty.
 8. Click the **OK** button. The new custom property updates with your new property name.


### PR DESCRIPTION
## Changes

Update creating-basic-heads.md mapping instructions to include a specific example of the correct convention for custom property names that map frame number to FACS pose.

The specific "Frame#" format is only visible in the videos and gave me trouble the other day while trying to make poses with zero prior experience.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
