### PR TITLE
Update UIListLayout to clarify Rotation property does not apply.

### DIFF
--- a/content/en-us/reference/engine/classes/UIListLayout.yaml
+++ b/content/en-us/reference/engine/classes/UIListLayout.yaml
@@ -9,7 +9,7 @@ description: |
   UI element, either horizontally or vertically. Each sibling UI element retains
   its original `Class.GuiObject.Size`, but its `Class.GuiObject.Position` will
   be taken under control by the UIListLayout. While under control, the Position
-  property of sibling UI elements will not be editable in the Properties window.
+  property of sibling UI elements will not be editable in the Properties window. Its `Class.GuiObject.Rotation` property will also be ignored.  
 
   You can use the elements' `Class.GuiObject.LayoutOrder` by changing
   `Class.UIListLayout.SortOrder` to LayoutOrder. A UIListLayout will


### PR DESCRIPTION
Rotation property is ignored for GUIObjects under the control of UIListLayout. This PR updates UIListLayout.yaml to clarify this behavior. It looks like it does confuse some people https://devforum.roblox.com/t/uilistlayout-prevents-rotation/1640720