### PR TITLE
Remove "CFrame cant be edited" from Tool.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/Tool.yaml
+++ b/content/en-us/reference/engine/classes/Tool.yaml
@@ -94,9 +94,10 @@ properties:
     summary: |
       Stores the tool's "grip" properties as one `Datatype.CFrame`.
     description: |
-      The Grip property stores the tool's "grip" properties as a single
+      The `Grip` property stores the tool's "grip" properties as a single
       `Datatype.CFrame`. These properties position how the player holds the tool
-      and include `GripUp`, `GripRight`, `GripForward`, and `GripPos`.
+      and include `Class.Tool.GripUp|GripUp`, `Class.Tool.GripRight|GripRight`,
+      `Class.Tool.GripForward|GripForward`, and `Class.Tool.GripPos|GripPos`.
     code_samples:
       - grip-stick
     type: CFrame

--- a/content/en-us/reference/engine/classes/Tool.yaml
+++ b/content/en-us/reference/engine/classes/Tool.yaml
@@ -97,11 +97,6 @@ properties:
       The Grip property stores the tool's "grip" properties as a single
       `Datatype.CFrame`. These properties position how the player holds the tool
       and include `GripUp`, `GripRight`, `GripForward`, and `GripPos`.
-
-      Unlike the grip properties that it stores, this consolidated property
-      doesn't appear in the [Properties](../../../studio/properties.md) window
-      in Studio. Regardless, you can set and get it from a `Class.Script` or
-      `Class.LocalScript`.
     code_samples:
       - grip-stick
     type: CFrame


### PR DESCRIPTION
## Changes

CFrames can now be edited from the property window, so this paragraph on Tool.Grip is invalid.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
