### PR TITLE
Add `continue` keyword documentation

### DIFF
--- a/content/en-us/luau/control-structures.md
+++ b/content/en-us/luau/control-structures.md
@@ -286,16 +286,16 @@ Five seconds elapsed. Time to move on!
 
 ### Continuing Loops
 
-To force a loop to iterate and start again, use the `continue` keyword. A `for` loop will iterate the counter, `while` and `repeat`..`until` will check the loop condition before continuing. The following code sample gets all children of an `Class.Instance` of a specific `Class.Instance.ClassName`.
+To force a loop to iterate and start again, use the `continue` keyword. A `for` loop will iterate the counter; `while` and `repeat`—`until` will check the loop condition before continuing. The following code sample gets all children of an `Class.Instance` of a specific `Class.Instance.ClassName|ClassName`.
 
 ```lua
 local function GetChildrenOfClass(parent: Instance, className: string): {Instance}
-  local children = {}
-  for _, child in parent:GetChildren() do
-    if child.ClassName ~= className then continue end -- iterates the for loop
-    table.insert(children, child)
-  end
+	local children = {}
+	for _, child in parent:GetChildren() do
+		if child.ClassName ~= className then continue end  -- Iterates the loop
+		table.insert(children, child)
+	end
 
-  return children
+	return children
 end
 ```

--- a/content/en-us/luau/control-structures.md
+++ b/content/en-us/luau/control-structures.md
@@ -299,5 +299,3 @@ local function GetChildrenOfClass(parent: Instance, className: string): {Instanc
   return children
 end
 ```
-
-

--- a/content/en-us/luau/control-structures.md
+++ b/content/en-us/luau/control-structures.md
@@ -252,6 +252,8 @@ World f
 ]]
 ```
 
+## Control Keywords
+
 ### Breaking Loops
 
 To force a loop to end, use the `break` command. The following code sample shows how to break an infinite `while`—`do` loop.
@@ -281,3 +283,21 @@ print("Five seconds elapsed. Time to move on!")
 Five seconds elapsed. Time to move on!
 ]]
 ```
+
+### Continuing Loops
+
+To force a loop to iterate and start again, use the `continue` statement. A `for` loop will iterate the counter, `while` and `repeat`..`until` will check the loop condition before continuing. The following code sample gets all children of an `Class.Instance` of a specific `Class.Instance.ClassName`.
+
+```lua
+local function GetChildrenOfClass(parent: Instance, className: string): {Instance}
+  local children = {}
+  for _, child in parent:GetChildren() do
+    if child.ClassName ~= className then continue end -- iterates the for loop
+    table.insert(children, child)
+  end
+
+  return children
+end
+```
+
+

--- a/content/en-us/luau/control-structures.md
+++ b/content/en-us/luau/control-structures.md
@@ -256,7 +256,7 @@ World f
 
 ### Breaking Loops
 
-To force a loop to end, use the `break` command. The following code sample shows how to break an infinite `while`—`do` loop.
+To force a loop to end, use the `break` keyword. The following code sample shows how to break an infinite `while`—`do` loop.
 
 ```lua
 local secondsElapsed = 0
@@ -286,7 +286,7 @@ Five seconds elapsed. Time to move on!
 
 ### Continuing Loops
 
-To force a loop to iterate and start again, use the `continue` statement. A `for` loop will iterate the counter, `while` and `repeat`..`until` will check the loop condition before continuing. The following code sample gets all children of an `Class.Instance` of a specific `Class.Instance.ClassName`.
+To force a loop to iterate and start again, use the `continue` keyword. A `for` loop will iterate the counter, `while` and `repeat`..`until` will check the loop condition before continuing. The following code sample gets all children of an `Class.Instance` of a specific `Class.Instance.ClassName`.
 
 ```lua
 local function GetChildrenOfClass(parent: Instance, className: string): {Instance}


### PR DESCRIPTION
## Changes

Adds documentation for the `continue` keyword.

(does creator docs support the language mode `luau`, right now the sample is `lua`, as this has syntax highlighting for continue?)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
