### PR TITLE
Add documentation for IsContentSharingAllowed in PolicyService response

### DIFF
--- a/content/en-us/reference/engine/classes/PolicyService.yaml
+++ b/content/en-us/reference/engine/classes/PolicyService.yaml
@@ -61,7 +61,7 @@ methods:
       <td>IsContentSharingAllowed</td>
       <td>Boolean</td>
       <td>Any experience that allows users to share content off platform</td>
-      <td>When true, the player is allowed to share content using APIs which open external sharing flows such as `Class.CaptureService:PromptShareCapture()`.</td>
+      <td>When true, the player is allowed to share content using APIs which open external sharing flows such as <code>Class.CaptureService:PromptShareCapture()</code>.</td>
       </tr>
       <tr>
       <td>IsEligibleToPurchaseSubscription</td>

--- a/content/en-us/reference/engine/classes/PolicyService.yaml
+++ b/content/en-us/reference/engine/classes/PolicyService.yaml
@@ -58,6 +58,12 @@ methods:
       <td>A list of external link references (for example, social media links, handles, or iconography) a player is permitted to see. Possible values include: "Discord", "Facebook", "Twitch", "Twitter", "YouTube", "X", "GitHub", and "Guilded".</td>
       </tr>
       <tr>
+      <td>IsContentSharingAllowed</td>
+      <td>Boolean</td>
+      <td>Any experience that allows users to share content off platform</td>
+      <td>When true, the player is allowed to share content using APIs which open external sharing flows such as `Class.CaptureService:PromptShareCapture()`.</td>
+      </tr>
+      <tr>
       <td>IsEligibleToPurchaseSubscription</td>
       <td>Boolean</td>
       <td>Any experience that wants to sell subscriptions</td>


### PR DESCRIPTION
## Changes

Add documentation for IsContentSharingAllowed in PolicyService response, this field specifies whether content can be shared via the CaptureService:PromptShareCapture API (which currently supports sharing screenshots via share sheet on the users device).

https://devforum.roblox.com/t/captures-apis-are-now-available/2838188

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
