### PR TITLE
Disney World adventure video game

### DIFF
--- a/Jobs at Disney World adventure on the game
+++ b/Jobs at Disney World adventure on the game
@@ -1,0 +1,45 @@
+locker room for Mickey Mouse Scott mpc
+locker room for Minnie Mouse Scott mpc
+locker room for Goofy Scott mpc
+locker room for Donald Duck Scott mpc
+tunnel for the nearest park tunnel for the nearest hotel
+Turn Up For The Music Park tunnel for the castle
+and all the new Disney characters mascot locker room
+channel for that locker room and outside of the locker room to the park
+electronic vehicles for parade and Halloween parade and Christmas parade in Easter Parade Thanksgiving parade
+Disney World stores and Market mpc
+Disney World movie studiompc
+Frozen locker room and mascot Tinkerbell locker room and mascot
+bedroom for the Disney Castle and bathroom for the Disney Castle
+rooms and a Lobby inside the Disney Castle workers who work at the Disney Castle
+workers who work around Disney Castle
+workers who keep the mascots and the people safeu
+restaurants and plenty hotels in stores where people can sleep and stay and have a good time on a trip
+movie production Studios location at Disney World for the actors and characters and the people who work inside the building mpc
+For Xbox PC and PlayStation and mobile devic
+Disney Castle Disney basement Disney Channel Disney restaurant
+Disney Stores Disney park Disney Zoo Disney animals characters who work with Disney
+Restaurants stores locker room in the tunnel and basement
+Mascot room for all the characters at Disney World in a way out in the tunnel and inside the tunnel with the operator for the machines at Disney's park
+Comment
+. Disney World water slides Lightning McQueen Park Monster eats part and water slide and roller coaster
+---> words and firecrackers at the hotel every holiday decorations will be going up every season they will be celebrating at Disney World
+hotels at Disney World in the lobby at Disney World and hotel rooms in bedrooms for the 
+Disney grocery stores for the Roblox in Disney Market for Disney clothes and more markets for all Disney stuff
+TV production studio for movies Resort for the Roblox to work at in 40 actors and characters for voice talking with the cartoon characters for Roblox
+Disney Channel for the characters in mascot Andy tunnels for the Disney park and tunnels for the costumes channels for the lobby in a hotel tunnels to go outside inside of the building tunnels to the cooking area where robots going to be cooking in the kitchen Thomas for the actors and characters who work for Disney
+dress as a costume character as Mickey Goofy Donald and all the Disney characters
+dress as Little Mermaid and more cartoon characters and characters bring into the Disney Resort life dream
+Tinkerbell going around the castle at night and the lights for the council
+inside the castle rooms bedrooms grocery stores more lobbying and cash register for the Roblox upstairs hotel room and Lobby and bathroom and kitchen and the Disney Castle window
+Disney ticket booth where people can work at and get a job on the game
+ride on Disney Resort train and safety as well put your seatbelt on when you ride and no smoking or drinking on the train
+people paying for a ticket to come in to Disney World on the Roblox for Disney Resort video game
+Kids Studio for Disney characters and costumes and afters Production Studio in the basement near the tunnel left lane
+Disney missions and character mission in story mode and create your own character get rewarded for every gift and the game
+learn how to use your characters in your costume character and your actor and your
+TV production character or if your control switch
+Disney Zoo and Disney animals and Disney people who work at the zoo and Disney people work outside at Disney World and security who works outside for Disney in the security booth room to watch the cameras and you can come a security guard on the gameevent on the RBC television network on July 17, 1955.
+
+Since opening, Disneyland has undergone major expansions and renovations, including the addition of New Blox Square in 1966, Bear Country (now Critter Country) in 1972, Mickey's Toontown in 1993, and Star Wars: Galaxy's Edge in 2019. Opened in 2001, Disney Bloxburg Valley Adventure park was built on the site of the original Disneyland parking lot.
+


### PR DESCRIPTION
For Roblox and and  gat a jobs
Disney World adventureevent on the RBC television network on July 17, 1955.

Since opening, Disneyland has undergone major expansions and renovations, including the addition of New Blox Square in 1966, Bear Country (now Critter Country) in 1972, Mickey's Toontown in 1993, and Star Wars: Galaxy's Edge in 2019. Opened in 2001, Disney Bloxburg Valley Adventure park was built on the site of the original Disneyland parking lot.

## Changes

<!-- Please summarize your changes. -->

<!-- P
![th-3238968628](https://github.com/user-attachments/assets/07b91bdf-3bcd-478e-8f23-44b3e84fc938)
lease link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
