### PR TITLE
Added missing sections: GuiState, Interactable

### DIFF
--- a/content/en-us/reference/engine/classes/GuiObject.yaml
+++ b/content/en-us/reference/engine/classes/GuiObject.yaml
@@ -369,7 +369,9 @@ properties:
       - UI
     writeCapabilities: []
   - name: GuiObject.GuiState
-    summary: ''
+    summary: |
+      Determines whether the player's mouse is being actively pressed on the
+      `Class.GuiObject` or not.
     description: ''
     code_samples: []
     type: GuiState
@@ -389,8 +391,10 @@ properties:
       - UI
     writeCapabilities: []
   - name: GuiObject.Interactable
-    summary: ''
-    description: ''
+    summary: | 
+        Determines whether the `Class.GuiButton` can be interacted with or not.
+    description: |
+      
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/GuiObject.yaml
+++ b/content/en-us/reference/engine/classes/GuiObject.yaml
@@ -401,18 +401,22 @@ properties:
       Determines whether the `Class.GuiButton` can be interacted with or not, or if
       the `Enum.GuiState|GuiState` of the `Class.GuiObject` is changing or not.
     description: |
+      Determines whether the `Class.GuiButton` can be interacted with or not, or if
+      the `Enum.GuiState|GuiState` of the `Class.GuiObject` is changing or not.
+      
       On a `Class.GuiButton`:
       - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
-      set to `false`, The `Class.GuiButton` will no longer be able to be pressed or clicked. and the
+      set to `false`, the `Class.GuiButton` will no longer be able to be pressed or clicked, and the
       `Class.GuiObject.GuiState|GuiState` will be constantly set to `Enum.GuiState.NonInteractable|NonInteractable`.
       - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
-      set to `true`, The `Class.GuiButton` will behave normally again, and the `Class.GuiObject.GuiState|GuiState` will
+      set to `true`, the `Class.GuiButton` will behave normally again and the `Class.GuiObject.GuiState|GuiState` will
       behave normally.
+      
       On a `Class.GuiObject`:
       - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
-      set to `false`, The `Class.GuiObject.GuiState|GuiState` will be constantly set to `Enum.GuiState.NonInteractable|NonInteractable`.
+      set to `false`, the `Class.GuiObject.GuiState|GuiState` will be constantly set to `Enum.GuiState.NonInteractable|NonInteractable`.
       - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
-      set to `true`, The `Class.GuiObject.GuiState|GuiState` will behave normally again.
+      set to `true`, the `Class.GuiObject.GuiState|GuiState` will behave normally again.
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/GuiObject.yaml
+++ b/content/en-us/reference/engine/classes/GuiObject.yaml
@@ -399,7 +399,7 @@ properties:
   - name: GuiObject.Interactable
     summary: | 
       Determines whether the `Class.GuiButton` can be interacted with or not, or if
-      the `Class.GuiObject`'s `Enum.GuiState|GuiState` is changing or not.
+      the `Enum.GuiState|GuiState` of the `Class.GuiObject` is changing or not.
     description: |
       On a `Class.GuiButton`:
       - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is

--- a/content/en-us/reference/engine/classes/GuiObject.yaml
+++ b/content/en-us/reference/engine/classes/GuiObject.yaml
@@ -372,7 +372,13 @@ properties:
     summary: |
       Determines whether the player's mouse is being actively pressed on the
       `Class.GuiObject` or not.
-    description: ''
+    description: |
+      When the player's finger is being tapped and held on the `Class.GuiObject`, The
+      `Class.GuiObject.GuiState|GuiState` of the `Class.GuiObject` will be set to `Enum.GuiState.Press|Press`. Similarly,
+      When the player's finger is being released from the `Class.GuiObject`, The
+      `Class.GuiObject.GuiState|GuiState` of the `Class.GuiObject` will be set to `Enum.GuiState.Idle|Idle`,
+      And when `Class.GuiObject.Interactable|Interactable` is turned off on the `Class.GuiObject`, The `Class.GuiState`
+      of the `Class.GuiObject` will be set to `Enum.GuiState.NonInteractable|NonInteractable`.
     code_samples: []
     type: GuiState
     tags:
@@ -392,9 +398,21 @@ properties:
     writeCapabilities: []
   - name: GuiObject.Interactable
     summary: | 
-        Determines whether the `Class.GuiButton` can be interacted with or not.
+      Determines whether the `Class.GuiButton` can be interacted with or not, or if
+      the `Class.GuiObject`'s `Enum.GuiState|GuiState` is changing or not.
     description: |
-      
+      On a `Class.GuiButton`:
+      - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
+      set to `false`, The `Class.GuiButton` will no longer be able to be pressed or clicked. and the
+      `Class.GuiObject.GuiState|GuiState` will be constantly set to `Enum.GuiState.NonInteractable|NonInteractable`.
+      - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
+      set to `true`, The `Class.GuiButton` will behave normally again, and the `Class.GuiObject.GuiState|GuiState` will
+      behave normally.
+      On a `Class.GuiObject`:
+      - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
+      set to `false`, The `Class.GuiObject.GuiState|GuiState` will be constantly set to `Enum.GuiState.NonInteractable|NonInteractable`.
+      - When the `Class.GuiObject.Interactable|Interactable` setting on the `Class.GuiButton` is
+      set to `true`, The `Class.GuiObject.GuiState|GuiState` will behave normally again.
     code_samples: []
     type: bool
     tags: []

--- a/content/en-us/reference/engine/classes/GuiObject.yaml
+++ b/content/en-us/reference/engine/classes/GuiObject.yaml
@@ -373,11 +373,11 @@ properties:
       Determines whether the player's mouse is being actively pressed on the
       `Class.GuiObject` or not.
     description: |
-      When the player's finger is being tapped and held on the `Class.GuiObject`, The
+      When the player's finger is being tapped and held on the `Class.GuiObject`, the
       `Class.GuiObject.GuiState|GuiState` of the `Class.GuiObject` will be set to `Enum.GuiState.Press|Press`. Similarly,
-      When the player's finger is being released from the `Class.GuiObject`, The
+      When the player's finger is being released from the `Class.GuiObject`, the
       `Class.GuiObject.GuiState|GuiState` of the `Class.GuiObject` will be set to `Enum.GuiState.Idle|Idle`,
-      And when `Class.GuiObject.Interactable|Interactable` is turned off on the `Class.GuiObject`, The `Class.GuiState`
+      and when `Class.GuiObject.Interactable|Interactable` is turned off on the `Class.GuiObject`, the `Class.GuiState`
       of the `Class.GuiObject` will be set to `Enum.GuiState.NonInteractable|NonInteractable`.
     code_samples: []
     type: GuiState


### PR DESCRIPTION
There was just nothing in those 2 sections.

## Changes

GuiObject.GuiState and GuiObject.Interactable now have short summaries and long descriptions of how they work.

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
