### PR TITLE
Improve table.move documentation

### DIFF
--- a/content/en-us/reference/engine/libraries/table.yaml
+++ b/content/en-us/reference/engine/libraries/table.yaml
@@ -344,8 +344,9 @@ functions:
     summary: |
       Copies the specified range of elements from one table to another.
     description: |
-      Copies elements from table `src` into table `dst`. Is equivalent to the
-      multiple assignment statement: `dst[t], ... = src[a], ..., src[b]`.
+      Copies elements in table `src` from `src[a]` up to `src[b]` into table
+      `dst` starting at `t`. Equivalent to the statement
+      `dst[t], ..., dst[t + (b - a)] = src[a], ..., src[b]`.
 
       The default for `dst` is `src`. The destination range may overlap with the
       source range.


### PR DESCRIPTION
## Changes

The existing documentation is fairly vague about how `move` operates, this clarifies the behaviour in an easier to understand manner.

Note: i'm unsure if the ending index in `dst` is actually `t + (b - a)`, will edit if not the case.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
