### PR TITLE
Fix "AirDenstiy" typo in AtmosphereSensor

### DIFF
--- a/content/en-us/reference/engine/classes/AtmosphereSensor.yaml
+++ b/content/en-us/reference/engine/classes/AtmosphereSensor.yaml
@@ -4,12 +4,12 @@ category:
 memory_category: Instances
 summary: |
   A `Class.SensorBase` that outputs data about the
-  `Class.AtmosphereSensor.AirDenstiy|AirDenstiy` and
+  `Class.AtmosphereSensor.AirDensity|AirDensity` and
   `Class.AtmosphereSensor.RelativeWindVelocity|RelativeWindVelocity` at the
   sensor's position.
 description: |
   A `Class.SensorBase` that outputs data about the
-  `Class.AtmosphereSensor.AirDenstiy|AirDenstiy` and
+  `Class.AtmosphereSensor.AirDensity|AirDensity` and
   `Class.AtmosphereSensor.RelativeWindVelocity|RelativeWindVelocity` at the
   sensor's position.
 code_samples: []


### PR DESCRIPTION
## Changes
Changed incorrect references to `AirDenstiy` in `reference/engine/classes/AtmosphereSensor.yaml` to `AirDensity`.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
