### PR TITLE
Fix inaccuracies in spawn and defer descriptions.

### DIFF
--- a/content/en-us/reference/engine/libraries/task.yaml
+++ b/content/en-us/reference/engine/libraries/task.yaml
@@ -20,8 +20,7 @@ functions:
     description: |
       Accepts a function or a thread (as returned by coroutine.create) and
       calls/resumes it immediately through the engine's scheduler. Arguments
-      after the first are sent to the function/thread. This function does not
-      return any value, even if the provided function returns one immediately.
+      after the first are sent to the function/thread.
 
       This function is based on the fastSpawn pattern rather than being a
       replacement for the deprecated global `spawn` function. It is recommended
@@ -55,12 +54,11 @@ functions:
       Calls/resumes a function/coroutine on the next resumption cycle.
     description: |
       Accepts a function or a thread (as returned by coroutine.create) and
-      defers it until the next
+      defers it until the end of the current
       [resumption cycle](https://devforum.roblox.com/t/1240569), at which point
       it is resumed with the engine's scheduler like with
       `Library.task.spawn()`. Arguments after the first are sent to the
-      function/thread. This function does not return any value, even if the
-      provided function returns one immediately.
+      function/thread.
 
       This function should be used when a similar behavior to
       `Library.task.spawn()` is desirable, but the thread does not need to run

--- a/content/en-us/reference/engine/libraries/task.yaml
+++ b/content/en-us/reference/engine/libraries/task.yaml
@@ -51,7 +51,7 @@ functions:
     code_samples:
   - name: task.defer
     summary: |
-      Calls/resumes a function/coroutine on the next resumption cycle.
+      Calls/resumes a function/coroutine at the end of the current resumption cycle.
     description: |
       Accepts a function or a thread (as returned by coroutine.create) and
       defers it until the end of the current

--- a/content/en-us/reference/engine/libraries/task.yaml
+++ b/content/en-us/reference/engine/libraries/task.yaml
@@ -55,7 +55,7 @@ functions:
     description: |
       Accepts a function or a thread (as returned by coroutine.create) and
       defers it until the end of the current
-      [resumption cycle](https://devforum.roblox.com/t/1240569), at which point
+      resumption cycle, at which point
       it is resumed with the engine's scheduler like with
       `Library.task.spawn()`. Arguments after the first are sent to the
       function/thread.


### PR DESCRIPTION
## Changes

- Fixes `task.defer` description that stated that it runs the code on the next resumption cycle. This is false. It runs at the end of the _current_ resumption cycle.
- Fixes `task.defer` and `task.spawn` inaccuracy that states they do not return anything. They both return a thread object, which is reflected in the return value section of the documentation. Thus, these sentences are removed.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
