### PR TITLE
offsetStudsU/offsetStudsV fix

### DIFF
--- a/content/en-us/reference/engine/classes/Texture.yaml
+++ b/content/en-us/reference/engine/classes/Texture.yaml
@@ -97,7 +97,7 @@ properties:
       coordinate.
     description: |
       **OffsetStudsV** determines how far the rendered texture is offset on the
-      horizontal axis in studs.
+      vertical axis in studs.
 
       #### Example
 


### PR DESCRIPTION
## Changes

- The documentation for [OffsetStudsU](https://create.roblox.com/docs/reference/engine/classes/Texture#OffsetStudsU) and [OffsetStudsV](https://create.roblox.com/docs/reference/engine/classes/Texture#OffsetStudsV) were the same.
- Fixed the documentation for the axis direction of OffsetStudsV

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
