### PR TITLE
Update MarketplaceService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/MarketplaceService.yaml
+++ b/content/en-us/reference/engine/classes/MarketplaceService.yaml
@@ -598,7 +598,7 @@ methods:
         </tr>
       	<tr>
       	  <td><code>DisplaySubscriptionPeriod</code></td>
-      	  <td>number</td>
+      	  <td>string</td>
           <td>Localized subscription period text for display (for example, <code>/month</code>). Can be used together with <code>DisplayPrice</code>.</td>
         </tr>
       	<tr>


### PR DESCRIPTION
Fixed DisplaySubscriptionPeriod type being incorrectly set to a number instead of string

## Changes

<!-- Please summarize your changes. -->

Just a type correction on the docs, I tried referencing this and got back `/month` instead of a number.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
