### PR TITLE
add info about runcontext to bubble chat docs

### DIFF
--- a/content/en-us/chat/bubble-chat.md
+++ b/content/en-us/chat/bubble-chat.md
@@ -439,7 +439,7 @@ end
 
 You can display chat bubbles for non-player characters (NPCs) by calling `Class.TextChatService:DisplayBubble()`, with the NPC character and the message as parameters. These bubbles are customizable using the `Class.TextChatService.OnBubbleAdded` callback just like any other chat bubble.
 
-`Class.TextChatService:DisplayBubble()` only works on client-side scripts, so be sure to use a `Class.LocalScript` in an [appropriate container](/projects/data-model#client), such as `Class.StarterPlayerScripts`. If you attach a `Class.ProximityPrompt` to an NPC, a script for displaying a chat bubble might look like this:
+`Class.TextChatService:DisplayBubble()` only works on client-side scripts, so be sure to use a `Class.Script` with `Class.BaseScript.RunContext|RunContext` set to `Enum.RunContext.Client`, or a `Class.LocalScript` in an [appropriate container](/projects/data-model#client), such as `Class.StarterPlayerScripts`. If you attach a `Class.ProximityPrompt` to an NPC, a script for displaying a chat bubble might look like this:
 
 ```lua
 local TextChatService = game:GetService("TextChatService")


### PR DESCRIPTION
## Changes

Adds info about using a `Script` with its `RunContext` set to `Client`, instead of just a `LocalScript`.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
