### PR TITLE
Clarify resource owner `U` in OAuth2 reference

### DIFF
--- a/content/en-us/cloud/reference/oauth2.md
+++ b/content/en-us/cloud/reference/oauth2.md
@@ -252,6 +252,8 @@ curl --location --request POST https://apis.roblox.com/oauth/v1/token/resources'
 
 <h4>Response</h4>
 
+The value `U` in `ids` indicates that a scope has granted access to a resource owned by the authorizing `owner`.
+
 ```json title="Example Obtain Token Resources Response"
 {
   "resource_infos": [
@@ -263,6 +265,9 @@ curl --location --request POST https://apis.roblox.com/oauth/v1/token/resources'
       "resources": {
         "universe": {
           "ids": ["3828411582"]
+        },
+        "creator": {
+          "ids": ["U"]
         }
       }
     }


### PR DESCRIPTION
## Changes

This PR adds some clarification on the OAuth2 resources endpoint response, where the endpoint may sometimes return a value of `U` in the `ids` list which is equivalent to the authorizing resource owner's ID.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
