### PR TITLE
Remove "Twitter"

### DIFF
--- a/content/en-us/reference/engine/classes/PolicyService.yaml
+++ b/content/en-us/reference/engine/classes/PolicyService.yaml
@@ -55,7 +55,7 @@ methods:
       <td>AllowedExternalLinkReferences</td>
       <td>Array of strings</td>
       <td>Any experience that references external links</td>
-      <td>A list of external link references (for example, social media links, handles, or iconography) a player is permitted to see. Possible values include: "Discord", "Facebook", "Twitch", "Twitter", "YouTube", "X", "GitHub", and "Guilded".</td>
+      <td>A list of external link references (for example, social media links, handles, or iconography) a player is permitted to see. Possible values include: "Discord", "Facebook", "Twitch", "YouTube", "X", "GitHub", and "Guilded".</td>
       </tr>
       <tr>
       <td>IsContentSharingAllowed</td>


### PR DESCRIPTION
When using GetPolicyInfoForPlayerAsync, the AllowedExternalLinkReferences array no longer includes 'Twitter'.

## Changes

Removed "Twitter" from the list of possible values in the description for AllowedExternalLinkReferences.

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
