### PR TITLE
Fix buffer.writeu16 int number range

### DIFF
--- a/content/en-us/reference/engine/libraries/buffer.yaml
+++ b/content/en-us/reference/engine/libraries/buffer.yaml
@@ -366,7 +366,7 @@ functions:
         type: number
         default:
         summary: |
-          An integer number in range [0, 65,536].
+          An integer number in range [0, 65,535].
     returns:
       - type: void
         summary: ''


### PR DESCRIPTION
## Changes
This pr fixes the integer number range for the value parameter in buffer.writeu16. Which is currently written as [0, 65536], where it should be [0, 65535]

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
