### PR TITLE
Random:NextNumber() clarifications

### DIFF
--- a/content/en-us/reference/engine/datatypes/Random.yaml
+++ b/content/en-us/reference/engine/datatypes/Random.yaml
@@ -55,7 +55,7 @@ methods:
     summary: |
       Returns a pseudorandom number uniformly distributed over `[0, 1]`.
     description: |
-      Returns a uniform pseudo-random real number in the range of 0 to 1, 
+      Returns a uniform pseudorandom real number in the range of 0 to 1, 
       inclusive.
     parameters:
     returns:
@@ -68,7 +68,7 @@ methods:
     summary: |
       Returns a pseudorandom number uniformly distributed over `[min, max]`.
     description: |
-      Returns a uniform pseudo-random real number in the range of `min` to 
+      Returns a uniform pseudorandom real number in the range of `min` to 
       `max`, inclusive.
     parameters:
       - name: min

--- a/content/en-us/reference/engine/datatypes/Random.yaml
+++ b/content/en-us/reference/engine/datatypes/Random.yaml
@@ -55,7 +55,8 @@ methods:
     summary: |
       Returns a pseudorandom number uniformly distributed over `[0, 1]`.
     description: |
-      Returns a pseudorandom number uniformly distributed over `[0, 1]`.
+      Returns a uniform pseudo-random real number in the range of 0 to 1, 
+      inclusive.
     parameters:
     returns:
       - type: number
@@ -67,7 +68,8 @@ methods:
     summary: |
       Returns a pseudorandom number uniformly distributed over `[min, max]`.
     description: |
-      Returns a pseudorandom number uniformly distributed over `[min, max]`.
+      Returns a uniform pseudo-random real number in the range of `min` to 
+      `max`, inclusive.
     parameters:
       - name: min
         type: number


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
math.random() explicitly mentions that exactly zero can be returned by reading it with basic number knowledge. However, Random:NextNumber() requires developers to know numerical range notation to determine that NextNumber can return exactly zero.

Apply the math.random() standard to Random:NextNumber().

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
[Found out about this in a hard way. Would like this post to be deleted due to me being embarassed by it](https://devforum.roblox.com/t/random-nextnumber-should-never-return-zero/3270962)

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
