### PR TITLE
Fixed another brush typo.md

### DIFF
--- a/content/en-us/tutorials/curriculums/core/building/create-an-environment-with-terrain.md
+++ b/content/en-us/tutorials/curriculums/core/building/create-an-environment-with-terrain.md
@@ -161,7 +161,7 @@ To apply materials to the island:
    </video>
 
 1. Navigate back to the **Terrain Editor** window, then in the **Brush Settings** and **Material Settings** sections,
-   1. Set **Base Size** to **3**.
+   1. Set **Brush Size** to **3**.
    1. Set **Material** to **Grass**.
 1. In the viewport, drag along the edges of the island to apply blades of grass, leaving space in the middle of the island for
    the spawn location and the initial platforms.


### PR DESCRIPTION
Fixed it from saying "Set Base Size to 3" to saying "Set Brush Size to 3"

## Changes

<!-- Please summarize your changes. -->
In Roblox Studio the terrain editor says brush size. The guide is saying to change the base size. I fixed the typo to say "Set Brush Size to 3"
<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
