### PR TITLE
Migrate Vector3 to vector

### DIFF
--- a/content/en-us/characters/pathfinding.md
+++ b/content/en-us/characters/pathfinding.md
@@ -145,7 +145,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = Vector3.new(100, 0, 100)
+local TEST_DESTINATION = vector.new(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -213,7 +213,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = Vector3.new(100, 0, 100)
+local TEST_DESTINATION = vector.new(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -245,7 +245,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = Vector3.new(100, 0, 100)
+local TEST_DESTINATION = vector.new(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -286,7 +286,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = Vector3.new(100, 0, 100)
+local TEST_DESTINATION = vector.new(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -358,7 +358,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = Vector3.new(100, 0, 100)
+local TEST_DESTINATION = vector.new(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -525,7 +525,7 @@ To create a `Class.PathfindingLink` using this example:
    local character = player.Character
    local humanoid = character:WaitForChild("Humanoid")
 
-   local TEST_DESTINATION = Vector3.new(228.9, 17.8, 292.5)
+   local TEST_DESTINATION = vector.new(228.9, 17.8, 292.5)
 
    local waypoints
    local nextWaypointIndex

--- a/content/en-us/characters/pathfinding.md
+++ b/content/en-us/characters/pathfinding.md
@@ -145,7 +145,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = vector.new(100, 0, 100)
+local TEST_DESTINATION = vector.create(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -213,7 +213,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = vector.new(100, 0, 100)
+local TEST_DESTINATION = vector.create(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -245,7 +245,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = vector.new(100, 0, 100)
+local TEST_DESTINATION = vector.create(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -286,7 +286,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = vector.new(100, 0, 100)
+local TEST_DESTINATION = vector.create(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -358,7 +358,7 @@ local player = Players.LocalPlayer
 local character = player.Character
 local humanoid = character:WaitForChild("Humanoid")
 
-local TEST_DESTINATION = vector.new(100, 0, 100)
+local TEST_DESTINATION = vector.create(100, 0, 100)
 
 local waypoints
 local nextWaypointIndex
@@ -525,7 +525,7 @@ To create a `Class.PathfindingLink` using this example:
    local character = player.Character
    local humanoid = character:WaitForChild("Humanoid")
 
-   local TEST_DESTINATION = vector.new(228.9, 17.8, 292.5)
+   local TEST_DESTINATION = vector.create(228.9, 17.8, 292.5)
 
    local waypoints
    local nextWaypointIndex

--- a/content/en-us/chat/examples/proximity-chat.md
+++ b/content/en-us/chat/examples/proximity-chat.md
@@ -28,7 +28,7 @@ local function getPositionFromUserId(userId: number)
   end
 
   -- Return a default position if the player or character cannot be found.
-  return Vector3.zero
+  return vector.zero
 end
 
 -- Set the ShouldDeliverCallback for the general channel to control message delivery.

--- a/content/en-us/chat/in-experience-text-chat.md
+++ b/content/en-us/chat/in-experience-text-chat.md
@@ -83,7 +83,7 @@ local function getPositionFromUserId(userId: number)
 	end
 
 	-- Return a default position if the player or character cannot be found
-	return Vector3.zero
+	return vector.zero
 end
 
 -- Set the callback for the general channel to control message delivery

--- a/content/en-us/education/build-it-play-it-island-of-move/animating-parts.md
+++ b/content/en-us/education/build-it-play-it-island-of-move/animating-parts.md
@@ -206,7 +206,7 @@ local inTween = false
 
 -- Customizable variables
 local TWEEN_TIME = 1
-local TWEEN_SCALE = Vector3.zero
+local TWEEN_SCALE = vector.zero
 
 -- Tween variables
 local tweenInfo = TweenInfo.new(

--- a/content/en-us/environment/global-wind.md
+++ b/content/en-us/environment/global-wind.md
@@ -50,8 +50,8 @@ local gustCycleDelay = 5  -- Max duration between gust cycles in seconds
 local gustCycleDuration = 3.5  -- Duration of each gust cycle in seconds
 
 -- During each gust cycle, a portion of "gust" will be added to "baseWind" in a ramped fashion
-local baseWind = vector.new(5, 0, 2)  -- Base wind speed and direction
-local gust = vector.new(25, 0, 10)  -- Gust speed and direction
+local baseWind = vector.create(5, 0, 2)  -- Base wind speed and direction
+local gust = vector.create(25, 0, 10)  -- Gust speed and direction
 local gustIntervals = 100  -- Number of iterations used to calculate each gust interval
 local dg = gustCycleDuration / gustIntervals
 local dgf = dg / gustCycleDuration

--- a/content/en-us/environment/global-wind.md
+++ b/content/en-us/environment/global-wind.md
@@ -50,8 +50,8 @@ local gustCycleDelay = 5  -- Max duration between gust cycles in seconds
 local gustCycleDuration = 3.5  -- Duration of each gust cycle in seconds
 
 -- During each gust cycle, a portion of "gust" will be added to "baseWind" in a ramped fashion
-local baseWind = Vector3.new(5, 0, 2)  -- Base wind speed and direction
-local gust = Vector3.new(25, 0, 10)  -- Gust speed and direction
+local baseWind = vector.new(5, 0, 2)  -- Base wind speed and direction
+local gust = vector.new(25, 0, 10)  -- Gust speed and direction
 local gustIntervals = 100  -- Number of iterations used to calculate each gust interval
 local dg = gustCycleDuration / gustIntervals
 local dgf = dg / gustCycleDuration

--- a/content/en-us/luau/native-code-gen.md
+++ b/content/en-us/luau/native-code-gen.md
@@ -74,8 +74,8 @@ local function sumComponentsSlow(v)
 	return v.X + v.Y + v.Z
 end
 
--- "v" is declared to be a Vector3; code specialized for vectors is generated
-local function sumComponentsFast(v: Vector3)
+-- "v" is declared to be a vector; code specialized for vectors is generated
+local function sumComponentsFast(v: vector)
 	return v.X + v.Y + v.Z
 end
 ```

--- a/content/en-us/luau/tuples.md
+++ b/content/en-us/luau/tuples.md
@@ -10,7 +10,7 @@ A **tuple** is a list of values. Many [methods](./functions.md#methods) and [cal
 If a [method](./functions.md#methods) or [callback](./functions.md#callbacks) accepts a tuple as a parameter, then it accepts multiple values. For example, the API Reference shows that the `Class.BindableFunction:Invoke()` method accepts a "Tuple" as a parameter, so it accepts multiple arguments.
 
 ```lua
-BindableFunction:Invoke(1, true, "string", vector.new(0, 0, 0))
+BindableFunction:Invoke(1, true, "string", vector.zero)
 ```
 
 ## Returns

--- a/content/en-us/luau/tuples.md
+++ b/content/en-us/luau/tuples.md
@@ -10,7 +10,7 @@ A **tuple** is a list of values. Many [methods](./functions.md#methods) and [cal
 If a [method](./functions.md#methods) or [callback](./functions.md#callbacks) accepts a tuple as a parameter, then it accepts multiple values. For example, the API Reference shows that the `Class.BindableFunction:Invoke()` method accepts a "Tuple" as a parameter, so it accepts multiple arguments.
 
 ```lua
-BindableFunction:Invoke(1, true, "string", Vector3.new(0, 0, 0))
+BindableFunction:Invoke(1, true, "string", vector.new(0, 0, 0))
 ```
 
 ## Returns

--- a/content/en-us/parts/terrain.md
+++ b/content/en-us/parts/terrain.md
@@ -471,7 +471,7 @@ To import a heightmap and optional colormap:
 You can script terrain generation using the `Class.Terrain` class. For example, to create terrain with grass material that fills a volume, you can use methods such as `Class.Terrain:FillBall()|FillBall()`, `Class.Terrain:FillBlock()|FillBlock()`, `Class.Terrain:FillCylinder()|FillCylinder()`, `Class.Terrain:FillRegion()|FillRegion()`, or `Class.Terrain:FillWedge()|FillWedge()`.
 
 ```lua title='Fill Block Volume'
-workspace.Terrain:FillBlock(CFrame.new(0, 0, 0), Vector3.new(4, 4, 4), Enum.Material.Grass)
+workspace.Terrain:FillBlock(CFrame.new(0, 0, 0), vector.new(4, 4, 4), Enum.Material.Grass)
 ```
 
 ## Large-Scale Editing

--- a/content/en-us/parts/terrain.md
+++ b/content/en-us/parts/terrain.md
@@ -471,7 +471,7 @@ To import a heightmap and optional colormap:
 You can script terrain generation using the `Class.Terrain` class. For example, to create terrain with grass material that fills a volume, you can use methods such as `Class.Terrain:FillBall()|FillBall()`, `Class.Terrain:FillBlock()|FillBlock()`, `Class.Terrain:FillCylinder()|FillCylinder()`, `Class.Terrain:FillRegion()|FillRegion()`, or `Class.Terrain:FillWedge()|FillWedge()`.
 
 ```lua title='Fill Block Volume'
-workspace.Terrain:FillBlock(CFrame.new(0, 0, 0), vector.new(4, 4, 4), Enum.Material.Grass)
+workspace.Terrain:FillBlock(CFrame.new(0, 0, 0), vector.create(4, 4, 4), Enum.Material.Grass)
 ```
 
 ## Large-Scale Editing

--- a/content/en-us/production/monetization/engagement-based-payouts.md
+++ b/content/en-us/production/monetization/engagement-based-payouts.md
@@ -75,7 +75,7 @@ local Players = game:GetService("Players")
 local teleporter = script.Parent
 local showModal = true
 
-local TELEPORT_POSITION = Vector3.new(1200, 200, 60)
+local TELEPORT_POSITION = vector.new(1200, 200, 60)
 
 -- Teleport character to exclusive area
 local function teleportPlayer(player)

--- a/content/en-us/production/monetization/engagement-based-payouts.md
+++ b/content/en-us/production/monetization/engagement-based-payouts.md
@@ -75,7 +75,7 @@ local Players = game:GetService("Players")
 local teleporter = script.Parent
 local showModal = true
 
-local TELEPORT_POSITION = vector.new(1200, 200, 60)
+local TELEPORT_POSITION = vector.create(1200, 200, 60)
 
 -- Teleport character to exclusive area
 local function teleportPlayer(player)

--- a/content/en-us/reference/engine/classes/AvatarCreationService.yaml
+++ b/content/en-us/reference/engine/classes/AvatarCreationService.yaml
@@ -69,39 +69,39 @@ methods:
       		[Enum.AssetType.DynamicHead] = {
       			["Bounds"] = {
       				["Classic"] = {
-      					["MinSize"]: Vector3,
-      					["MaxSize"]: Vector3,
+      					["MinSize"]: vector,
+      					["MaxSize"]: vector,
       			},
       				["ProportionsSlender"] = {
-      					["MinSize"]: Vector3,
-      					["MaxSize"]: Vector3,
+      					["MinSize"]: vector,
+      					["MaxSize"]: vector,
       				},
       				["ProportionsNormal"] = {
-      					["MinSize"]: Vector3,
-      					["MaxSize"]: Vector3,
+      					["MinSize"]: vector,
+      					["MaxSize"]: vector,
       				},
       			},
       			["SubParts"] = {
       				["Head"] = {
       					["NeckRigAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       					["FaceFrontAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       					["HatAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       					["HairAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       					["FaceCenterAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       				},
       			},
@@ -109,51 +109,51 @@ methods:
       		[Enum.AssetType.LeftArm] = {
       			["Bounds"] = {
       				["Classic"] = {
-      					["MinSize"]: Vector3,
-      					["MaxSize"]: Vector3,
+      					["MinSize"]: vector,
+      					["MaxSize"]: vector,
       				},
       				["ProportionsSlender"] = {
-      					["MinSize"]: Vector3,
-      					["MaxSize"]: Vector3,
+      					["MinSize"]: vector,
+      					["MaxSize"]: vector,
       				},
       				["ProportionsNormal"] = {
-      					["MinSize"]: Vector3,
-      					["MaxSize"]: Vector3,
+      					["MinSize"]: vector,
+      					["MaxSize"]: vector,
       				},
       			},
       			["SubParts"] = {
       				["LeftHand"] = {
       					["LeftWristRigAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       					["LeftGripAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       				},
       				["LeftUpperArm"] = {
       					["LeftShoulderRigAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       					["LeftShoulderAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       						["LeftElbowRigAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       				},
       				["LeftLowerArm"] = {
       					["LeftElbowRigAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       					["LeftWristRigAttachment"] = {
-      						["LowerBound"]: Vector3,
-      						["UpperBound"]: Vector3,
+      						["LowerBound"]: vector,
+      						["UpperBound"]: vector,
       					},
       				},
       			},
@@ -164,8 +164,8 @@ methods:
       		[Enum.AssetType.HairAccessory] = {
       			["Attachments"] = {
       				{
-      					["Size"]: Vector3,
-      					["Offset"]: Vector3,
+      					["Size"]: vector,
+      					["Offset"]: vector,
       					["Name"]: string,
       				},
       			},

--- a/content/en-us/reference/engine/classes/BillboardGui.yaml
+++ b/content/en-us/reference/engine/classes/BillboardGui.yaml
@@ -442,8 +442,8 @@ properties:
       part.Parent = workspace
 
       -- Move camera next to part. Wait a bit and then move camera
-      local cameraPosition0 = part.Position + Vector3.new(0, 0, 10)
-      local cameraPosition1 = part.Position + Vector3.new(0, 0, 20)
+      local cameraPosition0 = part.Position + vector.new(0, 0, 10)
+      local cameraPosition1 = part.Position + vector.new(0, 0, 20)
       camera.CFrame = CFrame.lookAt(cameraPosition0, part.Position)
 
       -- Contents of billboard will be visible here

--- a/content/en-us/reference/engine/classes/BodyAngularVelocity.yaml
+++ b/content/en-us/reference/engine/classes/BodyAngularVelocity.yaml
@@ -37,7 +37,7 @@ properties:
       second) into the desired [angular velocity][3] (radians per second). For
       example: Setting
       `Class.BodyAngularVelocity.AngularVelocity|AngularVelocity` to
-      `Vector3.new(0, 1, 0) * math.rad(360)` ≈ `Vector3.new(0, 6.283, 0)` will
+      `vector.new(0, 1, 0) * math.rad(360)` ≈ `vector.new(0, 6.283, 0)` will
       cause a part to spin around the Y axis once per second.
     code_samples:
     type: Vector3

--- a/content/en-us/reference/engine/classes/BodyAngularVelocity.yaml
+++ b/content/en-us/reference/engine/classes/BodyAngularVelocity.yaml
@@ -37,7 +37,7 @@ properties:
       second) into the desired [angular velocity][3] (radians per second). For
       example: Setting
       `Class.BodyAngularVelocity.AngularVelocity|AngularVelocity` to
-      `vector.new(0, 1, 0) * math.rad(360)` ≈ `vector.new(0, 6.283, 0)` will
+      `vector.create(0, 1, 0) * math.rad(360)` ≈ `vector.create(0, 6.283, 0)` will
       cause a part to spin around the Y axis once per second.
     code_samples:
     type: Vector3

--- a/content/en-us/reference/engine/classes/Camera.yaml
+++ b/content/en-us/reference/engine/classes/Camera.yaml
@@ -65,8 +65,8 @@ properties:
       The most intuitive way to position and orient the `Class.Camera` is by
       using the `Datatype.CFrame.lookAt()` constructor. In the following
       example, the `Class.Camera` is positioned at
-      `Datatype.Vector3|vector.new(0, 10, 0)` and is oriented to be looking towards
-      `Datatype.Vector3|vector.new(10, 0, 0)`.
+      `Datatype.Vector3|vector.create(0, 10, 0)` and is oriented to be looking towards
+      `Datatype.Vector3|vector.create(10, 0, 0)`.
 
       ```lua
       local Workspace = game:GetService("Workspace")
@@ -74,8 +74,8 @@ properties:
       local camera = Workspace.CurrentCamera
       camera.CameraType = Enum.CameraType.Scriptable
 
-      local pos = vector.new(0, 10, 0)
-      local lookAtPos = vector.new(10, 0, 0)
+      local pos = vector.create(0, 10, 0)
+      local lookAtPos = vector.create(10, 0, 0)
 
       Workspace.CurrentCamera.CFrame = CFrame.lookAt(pos, lookAtPos)
       ```
@@ -104,7 +104,7 @@ properties:
         	character = player.CharacterAdded:Wait()
         end
 
-        local pos = camera.CFrame * vector.new(0, 20, 0)
+        local pos = camera.CFrame * vector.create(0, 20, 0)
         local lookAtPos = character.PrimaryPart.Position
         local targetCFrame = CFrame.lookAt(pos, lookAtPos)
 
@@ -715,8 +715,8 @@ methods:
       local camera = Workspace.CurrentCamera
 
       local castPoints = {
-      	vector.new(0, 10, 0),
-      	vector.new(0, 15, 0)
+      	vector.create(0, 10, 0),
+      	vector.create(0, 15, 0)
       }
       local ignoreList = {}
 
@@ -810,7 +810,7 @@ methods:
       local function getActualRoll()
       	local camera = workspace.CurrentCamera
 
-      	local trueUp = vector.new(0, 1, 0)
+      	local trueUp = vector.create(0, 1, 0)
       	local cameraUp = camera:GetRenderCFrame().upVector
 
       	return math.acos(trueUp:Dot(cameraUp))
@@ -1291,7 +1291,7 @@ methods:
 
       local camera = Workspace.CurrentCamera
 
-      local worldPoint = vector.new(0, 10, 0)
+      local worldPoint = vector.create(0, 10, 0)
       local vector, onScreen = camera:WorldToScreenPoint(worldPoint)
 
       local screenPoint = Vector2.new(vector.X, vector.Y)
@@ -1350,7 +1350,7 @@ methods:
 
       local camera = Workspace.CurrentCamera
 
-      local worldPoint = vector.new(0, 10, 0)
+      local worldPoint = vector.create(0, 10, 0)
       local vector, onScreen = camera:WorldToViewportPoint(worldPoint)
 
       local viewportPoint = Vector2.new(vector.X, vector.Y)

--- a/content/en-us/reference/engine/classes/Camera.yaml
+++ b/content/en-us/reference/engine/classes/Camera.yaml
@@ -65,8 +65,8 @@ properties:
       The most intuitive way to position and orient the `Class.Camera` is by
       using the `Datatype.CFrame.lookAt()` constructor. In the following
       example, the `Class.Camera` is positioned at
-      `Datatype.Vector3.new(0, 10, 0)` and is oriented to be looking towards
-      `Datatype.Vector3.new(10, 0, 0)`.
+      `Datatype.Vector3|vector.new(0, 10, 0)` and is oriented to be looking towards
+      `Datatype.Vector3|vector.new(10, 0, 0)`.
 
       ```lua
       local Workspace = game:GetService("Workspace")
@@ -74,8 +74,8 @@ properties:
       local camera = Workspace.CurrentCamera
       camera.CameraType = Enum.CameraType.Scriptable
 
-      local pos = Vector3.new(0, 10, 0)
-      local lookAtPos = Vector3.new(10, 0, 0)
+      local pos = vector.new(0, 10, 0)
+      local lookAtPos = vector.new(10, 0, 0)
 
       Workspace.CurrentCamera.CFrame = CFrame.lookAt(pos, lookAtPos)
       ```
@@ -104,7 +104,7 @@ properties:
         	character = player.CharacterAdded:Wait()
         end
 
-        local pos = camera.CFrame * Vector3.new(0, 20, 0)
+        local pos = camera.CFrame * vector.new(0, 20, 0)
         local lookAtPos = character.PrimaryPart.Position
         local targetCFrame = CFrame.lookAt(pos, lookAtPos)
 
@@ -715,8 +715,8 @@ methods:
       local camera = Workspace.CurrentCamera
 
       local castPoints = {
-      	Vector3.new(0, 10, 0),
-      	Vector3.new(0, 15, 0)
+      	vector.new(0, 10, 0),
+      	vector.new(0, 15, 0)
       }
       local ignoreList = {}
 
@@ -810,7 +810,7 @@ methods:
       local function getActualRoll()
       	local camera = workspace.CurrentCamera
 
-      	local trueUp = Vector3.new(0, 1, 0)
+      	local trueUp = vector.new(0, 1, 0)
       	local cameraUp = camera:GetRenderCFrame().upVector
 
       	return math.acos(trueUp:Dot(cameraUp))
@@ -1291,7 +1291,7 @@ methods:
 
       local camera = Workspace.CurrentCamera
 
-      local worldPoint = Vector3.new(0, 10, 0)
+      local worldPoint = vector.new(0, 10, 0)
       local vector, onScreen = camera:WorldToScreenPoint(worldPoint)
 
       local screenPoint = Vector2.new(vector.X, vector.Y)
@@ -1350,7 +1350,7 @@ methods:
 
       local camera = Workspace.CurrentCamera
 
-      local worldPoint = Vector3.new(0, 10, 0)
+      local worldPoint = vector.new(0, 10, 0)
       local vector, onScreen = camera:WorldToViewportPoint(worldPoint)
 
       local viewportPoint = Vector2.new(vector.X, vector.Y)

--- a/content/en-us/reference/engine/classes/EditableMesh.yaml
+++ b/content/en-us/reference/engine/classes/EditableMesh.yaml
@@ -115,14 +115,14 @@ description: |
   local function makeSharpCube()
   	local eMesh = AssetService:CreateEditableMesh()
 
-  	local v1 = eMesh:AddVertex(vector.new(0, 0, 0))
-  	local v2 = eMesh:AddVertex(vector.new(1, 0, 0))
-  	local v3 = eMesh:AddVertex(vector.new(0, 1, 0))
-  	local v4 = eMesh:AddVertex(vector.new(1, 1, 0))
-  	local v5 = eMesh:AddVertex(vector.new(0, 0, 1))
-  	local v6 = eMesh:AddVertex(vector.new(1, 0, 1))
-  	local v7 = eMesh:AddVertex(vector.new(0, 1, 1))
-  	local v8 = eMesh:AddVertex(vector.new(1, 1, 1))
+  	local v1 = eMesh:AddVertex(vector.create(0, 0, 0))
+  	local v2 = eMesh:AddVertex(vector.create(1, 0, 0))
+  	local v3 = eMesh:AddVertex(vector.create(0, 1, 0))
+  	local v4 = eMesh:AddVertex(vector.create(1, 1, 0))
+  	local v5 = eMesh:AddVertex(vector.create(0, 0, 1))
+  	local v6 = eMesh:AddVertex(vector.create(1, 0, 1))
+  	local v7 = eMesh:AddVertex(vector.create(0, 1, 1))
+  	local v8 = eMesh:AddVertex(vector.create(1, 1, 1))
 
   	addSharpQuad(eMesh, v5, v6, v8, v7)  -- Front
   	addSharpQuad(eMesh, v1, v3, v4, v2)  -- Back

--- a/content/en-us/reference/engine/classes/EditableMesh.yaml
+++ b/content/en-us/reference/engine/classes/EditableMesh.yaml
@@ -115,14 +115,14 @@ description: |
   local function makeSharpCube()
   	local eMesh = AssetService:CreateEditableMesh()
 
-  	local v1 = eMesh:AddVertex(Vector3.new(0, 0, 0))
-  	local v2 = eMesh:AddVertex(Vector3.new(1, 0, 0))
-  	local v3 = eMesh:AddVertex(Vector3.new(0, 1, 0))
-  	local v4 = eMesh:AddVertex(Vector3.new(1, 1, 0))
-  	local v5 = eMesh:AddVertex(Vector3.new(0, 0, 1))
-  	local v6 = eMesh:AddVertex(Vector3.new(1, 0, 1))
-  	local v7 = eMesh:AddVertex(Vector3.new(0, 1, 1))
-  	local v8 = eMesh:AddVertex(Vector3.new(1, 1, 1))
+  	local v1 = eMesh:AddVertex(vector.new(0, 0, 0))
+  	local v2 = eMesh:AddVertex(vector.new(1, 0, 0))
+  	local v3 = eMesh:AddVertex(vector.new(0, 1, 0))
+  	local v4 = eMesh:AddVertex(vector.new(1, 1, 0))
+  	local v5 = eMesh:AddVertex(vector.new(0, 0, 1))
+  	local v6 = eMesh:AddVertex(vector.new(1, 0, 1))
+  	local v7 = eMesh:AddVertex(vector.new(0, 1, 1))
+  	local v8 = eMesh:AddVertex(vector.new(1, 1, 1))
 
   	addSharpQuad(eMesh, v5, v6, v8, v7)  -- Front
   	addSharpQuad(eMesh, v1, v3, v4, v2)  -- Back

--- a/content/en-us/reference/engine/classes/Humanoid.yaml
+++ b/content/en-us/reference/engine/classes/Humanoid.yaml
@@ -1861,7 +1861,7 @@ methods:
       `Class.Workspace.CurrentCamera|CurrentCamera`.
 
       ```lua
-      humanoid:Move(Vector3.new(0, 0, -1), true)
+      humanoid:Move(vector.new(0, 0, -1), true)
       ```
 
       When this function is called, the `Class.Humanoid` will move until the

--- a/content/en-us/reference/engine/classes/Humanoid.yaml
+++ b/content/en-us/reference/engine/classes/Humanoid.yaml
@@ -1861,7 +1861,7 @@ methods:
       `Class.Workspace.CurrentCamera|CurrentCamera`.
 
       ```lua
-      humanoid:Move(vector.new(0, 0, -1), true)
+      humanoid:Move(vector.create(0, 0, -1), true)
       ```
 
       When this function is called, the `Class.Humanoid` will move until the

--- a/content/en-us/reference/engine/classes/Instance.yaml
+++ b/content/en-us/reference/engine/classes/Instance.yaml
@@ -1265,11 +1265,11 @@ methods:
       returned by default.
 
       For example, the following code snippet sets the instance's
-      **InitialPosition** attribute to `Datatype.Vector3|vector.new(0, 10, 0)`:
+      **InitialPosition** attribute to `Datatype.Vector3|vector.create(0, 10, 0)`:
 
       ```lua
       local part = workspace.Part
-      part:SetAttribute("InitialPosition", vector.new(0, 10, 0))
+      part:SetAttribute("InitialPosition", vector.create(0, 10, 0))
       ```
 
       #### Limitations

--- a/content/en-us/reference/engine/classes/Instance.yaml
+++ b/content/en-us/reference/engine/classes/Instance.yaml
@@ -1265,11 +1265,11 @@ methods:
       returned by default.
 
       For example, the following code snippet sets the instance's
-      **InitialPosition** attribute to `Datatype.Vector3|Vector3.new(0, 10, 0)`:
+      **InitialPosition** attribute to `Datatype.Vector3|vector.new(0, 10, 0)`:
 
       ```lua
       local part = workspace.Part
-      part:SetAttribute("InitialPosition", Vector3.new(0, 10, 0))
+      part:SetAttribute("InitialPosition", vector.new(0, 10, 0))
       ```
 
       #### Limitations

--- a/content/en-us/reference/engine/classes/RayValue.yaml
+++ b/content/en-us/reference/engine/classes/RayValue.yaml
@@ -12,7 +12,7 @@ description: |
   to create a new RayValue named "Value" within the `Class.Workspace`. It
   creates a ray at (0, 50, 0) and it faces in the positive-X direction.
 
-  `Instance.new("RayValue").Value = Ray.new(Vector3.new(0, 50, 0), Vector3.new(10, 0, 0))`
+  `Instance.new("RayValue").Value = Ray.new(vector.new(0, 50, 0), vector.new(10, 0, 0))`
 
   Since there is no trivial way to edit rays within Studio, sometimes it is
   better to use a CFrameValue instead (which can be changed through a part or

--- a/content/en-us/reference/engine/classes/RayValue.yaml
+++ b/content/en-us/reference/engine/classes/RayValue.yaml
@@ -12,7 +12,7 @@ description: |
   to create a new RayValue named "Value" within the `Class.Workspace`. It
   creates a ray at (0, 50, 0) and it faces in the positive-X direction.
 
-  `Instance.new("RayValue").Value = Ray.new(vector.new(0, 50, 0), vector.new(10, 0, 0))`
+  `Instance.new("RayValue").Value = Ray.new(vector.create(0, 50, 0), vector.create(10, 0, 0))`
 
   Since there is no trivial way to edit rays within Studio, sometimes it is
   better to use a CFrameValue instead (which can be changed through a part or

--- a/content/en-us/reference/engine/classes/UserInputService.yaml
+++ b/content/en-us/reference/engine/classes/UserInputService.yaml
@@ -317,7 +317,7 @@ properties:
       When sensitivity is 0, events that track the mouse's movement will still
       fire but all parameters and properties indicating the change in mouse
       position will return `Datatype.Vector2|Vector2.new()`, or
-      `Datatype.Vector3|Vector3.new()` in the case of `Class.InputObject.Delta`.
+      `Datatype.Vector3|vector.new()` in the case of `Class.InputObject.Delta`.
       For example, `Class.UserInputService:GetMouseDelta()|GetMouseDelta` will
       always return (0, 0).
     code_samples:
@@ -818,9 +818,9 @@ methods:
       The gravity vector is determined by the device's orientation relative to
       the real-world force of gravity. For instance, if a device is perfectly
       upright (portrait), the gravity vector is
-      `Datatype.Vector3|Vector3.new(0, 0, -9.18)`. If the left side of the
-      device is pointing down, the vector is Vector3.new(9.81, 0, 0). Finally,
-      if the back of the device is pointing down, the vector is Vector3.new(0,
+      `Datatype.Vector3|vector.new(0, 0, -9.18)`. If the left side of the
+      device is pointing down, the vector is vector.new(9.81, 0, 0). Finally,
+      if the back of the device is pointing down, the vector is vector.new(0,
       -9.81, 0).
 
       This function might be used to enable the user's device to impact or

--- a/content/en-us/reference/engine/classes/UserInputService.yaml
+++ b/content/en-us/reference/engine/classes/UserInputService.yaml
@@ -317,7 +317,7 @@ properties:
       When sensitivity is 0, events that track the mouse's movement will still
       fire but all parameters and properties indicating the change in mouse
       position will return `Datatype.Vector2|Vector2.new()`, or
-      `Datatype.Vector3|vector.new()` in the case of `Class.InputObject.Delta`.
+      `Datatype.Vector3|vector.create()` in the case of `Class.InputObject.Delta`.
       For example, `Class.UserInputService:GetMouseDelta()|GetMouseDelta` will
       always return (0, 0).
     code_samples:
@@ -818,9 +818,9 @@ methods:
       The gravity vector is determined by the device's orientation relative to
       the real-world force of gravity. For instance, if a device is perfectly
       upright (portrait), the gravity vector is
-      `Datatype.Vector3|vector.new(0, 0, -9.18)`. If the left side of the
-      device is pointing down, the vector is vector.new(9.81, 0, 0). Finally,
-      if the back of the device is pointing down, the vector is vector.new(0,
+      `Datatype.Vector3|vector.create(0, 0, -9.18)`. If the left side of the
+      device is pointing down, the vector is vector.create(9.81, 0, 0). Finally,
+      if the back of the device is pointing down, the vector is vector.create(0,
       -9.81, 0).
 
       This function might be used to enable the user's device to impact or

--- a/content/en-us/reference/engine/classes/ViewportFrame.yaml
+++ b/content/en-us/reference/engine/classes/ViewportFrame.yaml
@@ -165,7 +165,7 @@ properties:
     description: |
       A `Datatype.Vector3` representing the direction of the light source from
       position `Datatype.Vector3|vector.zero`. Defaults to
-      `Datatype.Vector3|vector.new(-1, -1, -1)`.
+      `Datatype.Vector3|vector.create(-1, -1, -1)`.
     code_samples:
     type: Vector3
     tags: []

--- a/content/en-us/reference/engine/classes/ViewportFrame.yaml
+++ b/content/en-us/reference/engine/classes/ViewportFrame.yaml
@@ -164,7 +164,7 @@ properties:
       A `Datatype.Vector3` representing the direction of the light source.
     description: |
       A `Datatype.Vector3` representing the direction of the light source from
-      position `Datatype.Vector3|vector.new(0, 0, 0)`. Defaults to
+      position `Datatype.Vector3|vector.zero`. Defaults to
       `Datatype.Vector3|vector.new(-1, -1, -1)`.
     code_samples:
     type: Vector3

--- a/content/en-us/reference/engine/classes/ViewportFrame.yaml
+++ b/content/en-us/reference/engine/classes/ViewportFrame.yaml
@@ -164,8 +164,8 @@ properties:
       A `Datatype.Vector3` representing the direction of the light source.
     description: |
       A `Datatype.Vector3` representing the direction of the light source from
-      position `Datatype.Vector3|Vector3.new(0, 0, 0)`. Defaults to
-      `Datatype.Vector3|Vector3.new(-1, -1, -1)`.
+      position `Datatype.Vector3|vector.new(0, 0, 0)`. Defaults to
+      `Datatype.Vector3|vector.new(-1, -1, -1)`.
     code_samples:
     type: Vector3
     tags: []

--- a/content/en-us/reference/engine/classes/WeldConstraint.yaml
+++ b/content/en-us/reference/engine/classes/WeldConstraint.yaml
@@ -131,10 +131,10 @@ properties:
       local partA = Instance.new("Part")
       local partB = Instance.new("Part")
 
-      partA.Position = Vector3.new(0, 10, 0)
+      partA.Position = vector.new(0, 10, 0)
       partA.Parent = workspace
 
-      partB.Position = Vector3.new(0, 10, 10)
+      partB.Position = vector.new(0, 10, 10)
       partB.Parent = workspace
 
       local weld = Instance.new("WeldConstraint")
@@ -174,10 +174,10 @@ properties:
       local partA = Instance.new("Part")
       local partB = Instance.new("Part")
 
-      partA.Position = Vector3.new(0, 10, 0)
+      partA.Position = vector.new(0, 10, 0)
       partA.Parent = workspace
 
-      partB.Position = Vector3.new(0, 10, 10)
+      partB.Position = vector.new(0, 10, 10)
       partB.Parent = workspace
 
       local weld = Instance.new("WeldConstraint")

--- a/content/en-us/reference/engine/classes/WeldConstraint.yaml
+++ b/content/en-us/reference/engine/classes/WeldConstraint.yaml
@@ -131,10 +131,10 @@ properties:
       local partA = Instance.new("Part")
       local partB = Instance.new("Part")
 
-      partA.Position = vector.new(0, 10, 0)
+      partA.Position = vector.create(0, 10, 0)
       partA.Parent = workspace
 
-      partB.Position = vector.new(0, 10, 10)
+      partB.Position = vector.create(0, 10, 10)
       partB.Parent = workspace
 
       local weld = Instance.new("WeldConstraint")
@@ -174,10 +174,10 @@ properties:
       local partA = Instance.new("Part")
       local partB = Instance.new("Part")
 
-      partA.Position = vector.new(0, 10, 0)
+      partA.Position = vector.create(0, 10, 0)
       partA.Parent = workspace
 
-      partB.Position = vector.new(0, 10, 10)
+      partB.Position = vector.create(0, 10, 10)
       partB.Parent = workspace
 
       local weld = Instance.new("WeldConstraint")

--- a/content/en-us/reference/engine/datatypes/Instance.yaml
+++ b/content/en-us/reference/engine/datatypes/Instance.yaml
@@ -24,12 +24,12 @@ constructors:
       ```lua
       -- Set new instance's parent last (recommended)
       local part = Instance.new("Part")
-      part.Position = vector.new(0, 10, 0)
+      part.Position = vector.create(0, 10, 0)
       part.Parent = workspace
 
       -- Set new instance's parent in constructor (discouraged)
       local part = Instance.new("Part", workspace)
-      part.Position = vector.new(0, 10, 0)
+      part.Position = vector.create(0, 10, 0)
       ````
     parameters:
       - name: className

--- a/content/en-us/reference/engine/datatypes/Instance.yaml
+++ b/content/en-us/reference/engine/datatypes/Instance.yaml
@@ -24,12 +24,12 @@ constructors:
       ```lua
       -- Set new instance's parent last (recommended)
       local part = Instance.new("Part")
-      part.Position = Vector3.new(0, 10, 0)
+      part.Position = vector.new(0, 10, 0)
       part.Parent = workspace
 
       -- Set new instance's parent in constructor (discouraged)
       local part = Instance.new("Part", workspace)
-      part.Position = Vector3.new(0, 10, 0)
+      part.Position = vector.new(0, 10, 0)
       ````
     parameters:
       - name: className

--- a/content/en-us/reference/engine/datatypes/PathWaypoint.yaml
+++ b/content/en-us/reference/engine/datatypes/PathWaypoint.yaml
@@ -9,11 +9,11 @@ description: |
   create points along a generated path.
 
   The code block below constructs a `Datatype.PathWaypoint` variable with
-  `Vector3.new(10, 10, 10)` as its position, `Enum.PathWaypointAction.Walk` as
+  `vector.new(10, 10, 10)` as its position, `Enum.PathWaypointAction.Walk` as
   its action, and `Custom Label` as its label:
 
   ```lua
-  local pos = Vector3.new(10, 10, 10)
+  local pos = vector.new(10, 10, 10)
   local waypoint = PathWaypoint.new(pos, Enum.PathWaypointAction.Walk, "Custom Label")
   ```
 
@@ -21,7 +21,7 @@ description: |
   property will be set to default as empty string.
 
   ```lua
-  local pos = Vector3.new(10, 10, 10)
+  local pos = vector.new(10, 10, 10)
   local waypoint = PathWaypoint.new(pos, Enum.PathWaypointAction.Walk)
   ```
 
@@ -69,7 +69,7 @@ constructors:
     parameters:
       - name: position
         type: Vector3
-        default: Vector3.new(0, 0, 0)
+        default: vector.zero
         summary: The 3D position of the waypoint.
       - name: action
         type: PathWaypointAction

--- a/content/en-us/reference/engine/datatypes/PathWaypoint.yaml
+++ b/content/en-us/reference/engine/datatypes/PathWaypoint.yaml
@@ -9,11 +9,11 @@ description: |
   create points along a generated path.
 
   The code block below constructs a `Datatype.PathWaypoint` variable with
-  `vector.new(10, 10, 10)` as its position, `Enum.PathWaypointAction.Walk` as
+  `vector.create(10, 10, 10)` as its position, `Enum.PathWaypointAction.Walk` as
   its action, and `Custom Label` as its label:
 
   ```lua
-  local pos = vector.new(10, 10, 10)
+  local pos = vector.create(10, 10, 10)
   local waypoint = PathWaypoint.new(pos, Enum.PathWaypointAction.Walk, "Custom Label")
   ```
 
@@ -21,7 +21,7 @@ description: |
   property will be set to default as empty string.
 
   ```lua
-  local pos = vector.new(10, 10, 10)
+  local pos = vector.create(10, 10, 10)
   local waypoint = PathWaypoint.new(pos, Enum.PathWaypointAction.Walk)
   ```
 

--- a/content/en-us/reference/engine/datatypes/Region3int16.yaml
+++ b/content/en-us/reference/engine/datatypes/Region3int16.yaml
@@ -36,8 +36,8 @@ description: |
   ```lua
   local function Region3int16toRegion3(region16)
   	return Region3.new(
-  		vector.new(region16.Min.X, region16.Min.Y, region16.Min.Z),
-  		vector.new(region16.Max.X, region16.Max.Y, region16.Max.Z)
+  		vector.create(region16.Min.X, region16.Min.Y, region16.Min.Z),
+  		vector.create(region16.Max.X, region16.Max.Y, region16.Max.Z)
   	)
   end
   ```

--- a/content/en-us/reference/engine/datatypes/Region3int16.yaml
+++ b/content/en-us/reference/engine/datatypes/Region3int16.yaml
@@ -36,8 +36,8 @@ description: |
   ```lua
   local function Region3int16toRegion3(region16)
   	return Region3.new(
-  		Vector3.new(region16.Min.X, region16.Min.Y, region16.Min.Z),
-  		Vector3.new(region16.Max.X, region16.Max.Y, region16.Max.Z)
+  		vector.new(region16.Min.X, region16.Min.Y, region16.Min.Z),
+  		vector.new(region16.Max.X, region16.Max.Y, region16.Max.Z)
   	)
   end
   ```

--- a/content/en-us/resources/battle-royale/building-system.md
+++ b/content/en-us/resources/battle-royale/building-system.md
@@ -135,7 +135,7 @@ For example, the **Wall** tile type is expressed as follows:
 
 ```lua
 ObjectTypeConfigurations.Wall = {
-	ASSET_OFFSET_FROM_CENTER = vector.new(0, 0, -CELL_DIMENSIONS.Z / 2),
+	ASSET_OFFSET_FROM_CENTER = vector.create(0, 0, -CELL_DIMENSIONS.Z / 2),
 	CONNECTIVITY = 0xFF8000, -- 0b 111 111 111 000 000 000 000 000
 	OCCUPANCY = 0x20, -- 0b 00 00 00 00 1 0 0 0 0 0
 }

--- a/content/en-us/resources/battle-royale/building-system.md
+++ b/content/en-us/resources/battle-royale/building-system.md
@@ -135,7 +135,7 @@ For example, the **Wall** tile type is expressed as follows:
 
 ```lua
 ObjectTypeConfigurations.Wall = {
-	ASSET_OFFSET_FROM_CENTER = Vector3.new(0, 0, -CELL_DIMENSIONS.Z / 2),
+	ASSET_OFFSET_FROM_CENTER = vector.new(0, 0, -CELL_DIMENSIONS.Z / 2),
 	CONNECTIVITY = 0xFF8000, -- 0b 111 111 111 000 000 000 000 000
 	OCCUPANCY = 0x20, -- 0b 00 00 00 00 1 0 0 0 0 0
 }

--- a/content/en-us/resources/battle-royale/minimap-system.md
+++ b/content/en-us/resources/battle-royale/minimap-system.md
@@ -62,7 +62,7 @@ To customize the minimap or use the minimap system with your own map and minimap
 <tbody>
   <tr>
     <td>`map_size`</td>
-    <td>The size of one edge of your map in studs. Note the minimap assumes your map is square and that the map center is located at this world point: `vector.new(map_size, 0, map_size)`.</td>
+    <td>The size of one edge of your map in studs. Note the minimap assumes your map is square and that the map center is located at this world point: `vector.create(map_size, 0, map_size)`.</td>
   </tr>
   <tr>
     <td>`minimap_width`</td>

--- a/content/en-us/resources/battle-royale/minimap-system.md
+++ b/content/en-us/resources/battle-royale/minimap-system.md
@@ -62,7 +62,7 @@ To customize the minimap or use the minimap system with your own map and minimap
 <tbody>
   <tr>
     <td>`map_size`</td>
-    <td>The size of one edge of your map in studs. Note the minimap assumes your map is square and that the map center is located at this world point: `Vector3.new(map_size, 0, map_size`).</td>
+    <td>The size of one edge of your map in studs. Note the minimap assumes your map is square and that the map center is located at this world point: `vector.new(map_size, 0, map_size)`.</td>
   </tr>
   <tr>
     <td>`minimap_width`</td>

--- a/content/en-us/resources/battle-royale/the-storm.md
+++ b/content/en-us/resources/battle-royale/the-storm.md
@@ -29,7 +29,7 @@ The default center of the storm is the center of the map, but you can change the
 
 ```lua
 map_size = 2450 * 4,
-map_offset = vector.new(4900, 0, 4900),
+map_offset = vector.create(4900, 0, 4900),
 ```
 
 ### Storm Options

--- a/content/en-us/resources/battle-royale/the-storm.md
+++ b/content/en-us/resources/battle-royale/the-storm.md
@@ -29,7 +29,7 @@ The default center of the storm is the center of the map, but you can change the
 
 ```lua
 map_size = 2450 * 4,
-map_offset = Vector3.new(4900, 0, 4900),
+map_offset = vector.new(4900, 0, 4900),
 ```
 
 ### Storm Options

--- a/content/en-us/resources/modules/surface-art.md
+++ b/content/en-us/resources/modules/surface-art.md
@@ -158,8 +158,8 @@ local SurfaceArt = require(ReplicatedStorage:WaitForChild("SurfaceArt"))
 local function createParticleEmitter(canvas, position)
 	local attachment = Instance.new("Attachment")
 	attachment.Position = canvas.CFrame:PointToObjectSpace(position)
-	attachment.Axis = vector.new(0, 0, 1)
-	attachment.SecondaryAxis = vector.new(1, 0, 0)
+	attachment.Axis = vector.create(0, 0, 1)
+	attachment.SecondaryAxis = vector.create(1, 0, 0)
 	attachment.Parent = canvas
 
 	local particleEmitter = Instance.new("ParticleEmitter")

--- a/content/en-us/resources/modules/surface-art.md
+++ b/content/en-us/resources/modules/surface-art.md
@@ -158,8 +158,8 @@ local SurfaceArt = require(ReplicatedStorage:WaitForChild("SurfaceArt"))
 local function createParticleEmitter(canvas, position)
 	local attachment = Instance.new("Attachment")
 	attachment.Position = canvas.CFrame:PointToObjectSpace(position)
-	attachment.Axis = Vector3.new(0, 0, 1)
-	attachment.SecondaryAxis = Vector3.new(1, 0, 0)
+	attachment.Axis = vector.new(0, 0, 1)
+	attachment.SecondaryAxis = vector.new(1, 0, 0)
 	attachment.Parent = canvas
 
 	local particleEmitter = Instance.new("ParticleEmitter")

--- a/content/en-us/resources/the-mystery-of-duvall-drive/developing-a-moving-world.md
+++ b/content/en-us/resources/the-mystery-of-duvall-drive/developing-a-moving-world.md
@@ -172,7 +172,7 @@ In addition, we run the sequence to set textures, positions, and brightness, run
 ```lua
 beam.Texture = textures[info.textIdx]
 
-beamPart.Position = Vector3.new(info.center.X + og_center.X, og_center.Y, info.center.Y + og_center.Z)
+beamPart.Position = vector.new(info.center.X + og_center.X, og_center.Y, info.center.Y + og_center.Z)
 
 -- Wipe
 beam.Brightness = 10

--- a/content/en-us/resources/the-mystery-of-duvall-drive/developing-a-moving-world.md
+++ b/content/en-us/resources/the-mystery-of-duvall-drive/developing-a-moving-world.md
@@ -172,7 +172,7 @@ In addition, we run the sequence to set textures, positions, and brightness, run
 ```lua
 beam.Texture = textures[info.textIdx]
 
-beamPart.Position = vector.new(info.center.X + og_center.X, og_center.Y, info.center.Y + og_center.Z)
+beamPart.Position = vector.create(info.center.X + og_center.X, og_center.Y, info.center.Y + og_center.Z)
 
 -- Wipe
 beam.Brightness = 10

--- a/content/en-us/scripting/attributes.md
+++ b/content/en-us/scripting/attributes.md
@@ -77,7 +77,7 @@ Properties are straightforward to access — just use a `.` after the object ref
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local chair = ReplicatedStorage:WaitForChild("Chair")
 
-chair.LeftArmRest.Size = Vector3.new(10, 1, 10)
+chair.LeftArmRest.Size = vector.new(10, 1, 10)
 ```
 
 ## Creating Attributes

--- a/content/en-us/scripting/attributes.md
+++ b/content/en-us/scripting/attributes.md
@@ -77,7 +77,7 @@ Properties are straightforward to access — just use a `.` after the object ref
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local chair = ReplicatedStorage:WaitForChild("Chair")
 
-chair.LeftArmRest.Size = vector.new(10, 1, 10)
+chair.LeftArmRest.Size = vector.create(10, 1, 10)
 ```
 
 ## Creating Attributes

--- a/content/en-us/scripting/events/remote.md
+++ b/content/en-us/scripting/events/remote.md
@@ -172,7 +172,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local remoteEvent = ReplicatedStorage:FindFirstChildOfClass("RemoteEvent")
 
 -- Fire the remote event and pass additional arguments
-remoteEvent:FireServer(Color3.fromRGB(255, 0, 0), vector.new(0, 25, -20))
+remoteEvent:FireServer(Color3.fromRGB(255, 0, 0), vector.create(0, 25, -20))
 ```
 
 ### Server&nbsp;→ Client
@@ -342,7 +342,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local remoteFunction = ReplicatedStorage:FindFirstChildOfClass("RemoteFunction")
 
 -- Pass a color and position when invoking the callback
-local newPart = remoteFunction:InvokeServer(Color3.fromRGB(255, 0, 0), vector.new(0, 25, -20))
+local newPart = remoteFunction:InvokeServer(Color3.fromRGB(255, 0, 0), vector.create(0, 25, -20))
 
 -- Output the returned part reference
 print("The server created the requested part:", newPart)

--- a/content/en-us/scripting/events/remote.md
+++ b/content/en-us/scripting/events/remote.md
@@ -172,7 +172,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local remoteEvent = ReplicatedStorage:FindFirstChildOfClass("RemoteEvent")
 
 -- Fire the remote event and pass additional arguments
-remoteEvent:FireServer(Color3.fromRGB(255, 0, 0), Vector3.new(0, 25, -20))
+remoteEvent:FireServer(Color3.fromRGB(255, 0, 0), vector.new(0, 25, -20))
 ```
 
 ### Server&nbsp;→ Client
@@ -342,7 +342,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local remoteFunction = ReplicatedStorage:FindFirstChildOfClass("RemoteFunction")
 
 -- Pass a color and position when invoking the callback
-local newPart = remoteFunction:InvokeServer(Color3.fromRGB(255, 0, 0), Vector3.new(0, 25, -20))
+local newPart = remoteFunction:InvokeServer(Color3.fromRGB(255, 0, 0), vector.new(0, 25, -20))
 
 -- Output the returned part reference
 print("The server created the requested part:", newPart)

--- a/content/en-us/scripting/multithreading.md
+++ b/content/en-us/scripting/multithreading.md
@@ -300,12 +300,12 @@ end
 -- Bind the callback to be called in parallel execution context
 actor:BindToMessageParallel("GenerateChunk", function(x, y, z, seed)
 	local voxels = generateVoxelsWithSeed(x, y, z, seed)
-	local corner = vector.new(x * 16, y * 16, z * 16)
+	local corner = vector.create(x * 16, y * 16, z * 16)
 
 	-- Currently, WriteVoxels() must be called in the serial phase
 	task.synchronize()
 	workspace.Terrain:WriteVoxels(
-		Region3.new(corner, corner + vector.new(16, 16, 16)),
+		Region3.new(corner, corner + vector.create(16, 16, 16)),
 		4,
 		voxels.materials,
 		voxels.occupancy

--- a/content/en-us/scripting/multithreading.md
+++ b/content/en-us/scripting/multithreading.md
@@ -300,12 +300,12 @@ end
 -- Bind the callback to be called in parallel execution context
 actor:BindToMessageParallel("GenerateChunk", function(x, y, z, seed)
 	local voxels = generateVoxelsWithSeed(x, y, z, seed)
-	local corner = Vector3.new(x * 16, y * 16, z * 16)
+	local corner = vector.new(x * 16, y * 16, z * 16)
 
 	-- Currently, WriteVoxels() must be called in the serial phase
 	task.synchronize()
 	workspace.Terrain:WriteVoxels(
-		Region3.new(corner, corner + Vector3.new(16, 16, 16)),
+		Region3.new(corner, corner + vector.new(16, 16, 16)),
 		4,
 		voxels.materials,
 		voxels.occupancy

--- a/content/en-us/scripting/security/security-tactics.md
+++ b/content/en-us/scripting/security/security-tactics.md
@@ -64,7 +64,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local remoteFunction = ReplicatedStorage:WaitForChild("RemoteFunctionTest")
 
 -- Pass part color and position when invoking the function
-local newPart = remoteFunction:InvokeServer(Color3.fromRGB(200, 0, 50), Vector3.new(0, 25, 0))
+local newPart = remoteFunction:InvokeServer(Color3.fromRGB(200, 0, 50), vector.new(0, 25, 0))
 
 if newPart then
 	print("The server created the requested part:", newPart)

--- a/content/en-us/scripting/security/security-tactics.md
+++ b/content/en-us/scripting/security/security-tactics.md
@@ -64,7 +64,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local remoteFunction = ReplicatedStorage:WaitForChild("RemoteFunctionTest")
 
 -- Pass part color and position when invoking the function
-local newPart = remoteFunction:InvokeServer(Color3.fromRGB(200, 0, 50), vector.new(0, 25, 0))
+local newPart = remoteFunction:InvokeServer(Color3.fromRGB(200, 0, 50), vector.create(0, 25, 0))
 
 if newPart then
 	print("The server created the requested part:", newPart)

--- a/content/en-us/sound/objects.md
+++ b/content/en-us/sound/objects.md
@@ -202,14 +202,14 @@ local RunService = game:GetService("RunService")
 local part = Instance.new("Part")
 part.Anchored = true
 part.Color = Color3.new(0.75, 0.2, 0.5)
-part.Size = vector.new(2, 1, 2)
+part.Size = vector.create(2, 1, 2)
 part.Material = Enum.Material.Neon
-part.Position = vector.new(0, 4, 0)
+part.Position = vector.create(0, 4, 0)
 part.Parent = workspace
 
 -- Create an attachment on the part
 local attachment = Instance.new("Attachment")
-attachment.Position = vector.new(0, 0.5, 0)
+attachment.Position = vector.create(0, 0.5, 0)
 attachment.Parent = part
 
 -- Create a particle emitter on the attachment

--- a/content/en-us/sound/objects.md
+++ b/content/en-us/sound/objects.md
@@ -202,14 +202,14 @@ local RunService = game:GetService("RunService")
 local part = Instance.new("Part")
 part.Anchored = true
 part.Color = Color3.new(0.75, 0.2, 0.5)
-part.Size = Vector3.new(2, 1, 2)
+part.Size = vector.new(2, 1, 2)
 part.Material = Enum.Material.Neon
-part.Position = Vector3.new(0, 4, 0)
+part.Position = vector.new(0, 4, 0)
 part.Parent = workspace
 
 -- Create an attachment on the part
 local attachment = Instance.new("Attachment")
-attachment.Position = Vector3.new(0, 0.5, 0)
+attachment.Position = vector.new(0, 0.5, 0)
 attachment.Parent = part
 
 -- Create a particle emitter on the attachment

--- a/content/en-us/tutorials/curriculums/gameplay-scripting/detecting-hits.md
+++ b/content/en-us/tutorials/curriculums/gameplay-scripting/detecting-hits.md
@@ -147,7 +147,7 @@ To prevent cheating, the previous chapter [Implementing Blasters](implementing-b
    Roblox abstracts away the most involved bits of math, so the result is a short, highly reusable helper function with applicability across a range of experiences:
 
    ```lua title="getAngleBetweenDirections"
-   local function getAngleBetweenDirections(directionA: Vector3, directionB: Vector3)
+   local function getAngleBetweenDirections(directionA: vector, directionB: vector)
        local dotProduct = directionA:Dot(directionB)
        local cosAngle = math.clamp(dotProduct, -1, 1)
        local angle = math.acos(cosAngle)

--- a/content/en-us/tutorials/fundamentals/coding-4/nested-loops.md
+++ b/content/en-us/tutorials/fundamentals/coding-4/nested-loops.md
@@ -47,7 +47,7 @@ Nested loops can seem somewhat abstract, so a visual example can help. For this 
    -- Makes a single cube
    local function createPart()
      local part = Instance.new("Part")
-     part.Size = vector.new(2, 2, 2)
+     part.Size = vector.create(2, 2, 2)
      part.CFrame = CFrame.new(20, 0, 20)
      part.Color = currentColor
      part.Parent = workspace
@@ -110,7 +110,7 @@ For the cube tower script, first code a function that spawns a single cube. The 
    -- Creates individual cubes
    local function makeCube()
      local cube = Instance.new("Part")
-     cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+     cube.Size = vector.create(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
    end
    ```
 
@@ -119,7 +119,7 @@ For the cube tower script, first code a function that spawns a single cube. The 
    ```lua
    local function makeCube()
      local cube = Instance.new("Part")
-     cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+     cube.Size = vector.create(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
      cube.Color = currentColor
    end
    ```
@@ -129,7 +129,7 @@ For the cube tower script, first code a function that spawns a single cube. The 
    ```lua
    local function makeCube()
        local cube = Instance.new("Part")
-       cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+       cube.Size = vector.create(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
        cube.Color = currentColor
        cube.Parent = workspace
    end
@@ -149,7 +149,7 @@ To create a tower, spawn cubes at specific points by setting the X, Y, Z propert
    -- Creates individual cubes
    local function makeCube(spawnX, spawnY, spawnZ)
        local cube = Instance.new("Part")
-       cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+       cube.Size = vector.create(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
        cube.Color = currentColor
        cube.Parent = workspace
    end
@@ -160,7 +160,7 @@ To create a tower, spawn cubes at specific points by setting the X, Y, Z propert
    ```lua
    local function makeCube(spawnX, spawnY, spawnZ)
        local cube = Instance.new("Part")
-       cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+       cube.Size = vector.create(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
        cube.Color = currentColor
        cube.CFrame = CFrame.new(spawnX, spawnY, spawnZ)
        cube.Parent = workspace
@@ -278,7 +278,7 @@ local CUBE_SIZE = 2
 -- Creates individual cubes
 local function makeCube(spawnX, spawnY, spawnZ)
     local cube = Instance.new("Part")
-    cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+    cube.Size = vector.create(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
     cube.Color = currentColor
     cube.Transparency = cubeTransparency -- Sets transparency
     cube.CFrame = CFrame.new(spawnX, spawnY, spawnZ)

--- a/content/en-us/tutorials/fundamentals/coding-4/nested-loops.md
+++ b/content/en-us/tutorials/fundamentals/coding-4/nested-loops.md
@@ -47,7 +47,7 @@ Nested loops can seem somewhat abstract, so a visual example can help. For this 
    -- Makes a single cube
    local function createPart()
      local part = Instance.new("Part")
-     part.Size = Vector3.new(2, 2, 2)
+     part.Size = vector.new(2, 2, 2)
      part.CFrame = CFrame.new(20, 0, 20)
      part.Color = currentColor
      part.Parent = workspace
@@ -110,7 +110,7 @@ For the cube tower script, first code a function that spawns a single cube. The 
    -- Creates individual cubes
    local function makeCube()
      local cube = Instance.new("Part")
-     cube.Size = Vector3.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+     cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
    end
    ```
 
@@ -119,7 +119,7 @@ For the cube tower script, first code a function that spawns a single cube. The 
    ```lua
    local function makeCube()
      local cube = Instance.new("Part")
-     cube.Size = Vector3.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+     cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
      cube.Color = currentColor
    end
    ```
@@ -129,7 +129,7 @@ For the cube tower script, first code a function that spawns a single cube. The 
    ```lua
    local function makeCube()
        local cube = Instance.new("Part")
-       cube.Size = Vector3.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+       cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
        cube.Color = currentColor
        cube.Parent = workspace
    end
@@ -149,7 +149,7 @@ To create a tower, spawn cubes at specific points by setting the X, Y, Z propert
    -- Creates individual cubes
    local function makeCube(spawnX, spawnY, spawnZ)
        local cube = Instance.new("Part")
-       cube.Size = Vector3.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+       cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
        cube.Color = currentColor
        cube.Parent = workspace
    end
@@ -160,7 +160,7 @@ To create a tower, spawn cubes at specific points by setting the X, Y, Z propert
    ```lua
    local function makeCube(spawnX, spawnY, spawnZ)
        local cube = Instance.new("Part")
-       cube.Size = Vector3.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+       cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
        cube.Color = currentColor
        cube.CFrame = CFrame.new(spawnX, spawnY, spawnZ)
        cube.Parent = workspace
@@ -278,7 +278,7 @@ local CUBE_SIZE = 2
 -- Creates individual cubes
 local function makeCube(spawnX, spawnY, spawnZ)
     local cube = Instance.new("Part")
-    cube.Size = Vector3.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
+    cube.Size = vector.new(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)
     cube.Color = currentColor
     cube.Transparency = cubeTransparency -- Sets transparency
     cube.CFrame = CFrame.new(spawnX, spawnY, spawnZ)

--- a/content/en-us/tutorials/use-case-tutorials/input-and-camera/controlling-the-users-camera.md
+++ b/content/en-us/tutorials/use-case-tutorials/input-and-camera/controlling-the-users-camera.md
@@ -124,7 +124,7 @@ All character models contain a part named **HumanoidRootPart**, which can be use
        if character then
            local root = character:FindFirstChild("HumanoidRootPart")
            if root then
-               local rootPosition = root.Position + Vector3.new(0, HEIGHT_OFFSET, 0)
+               local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
            end
        end
    end
@@ -150,8 +150,8 @@ local function updateCamera()
     if character then
         local root = character:FindFirstChild("HumanoidRootPart")
         if root then
-            local rootPosition = root.Position + Vector3.new(0, HEIGHT_OFFSET, 0)
-            local cameraPosition = Vector3.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
+            local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
+            local cameraPosition = vector.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
         end
     end
 end
@@ -176,8 +176,8 @@ local function updateCamera()
     if character then
         local root = character:FindFirstChild("HumanoidRootPart")
         if root then
-            local rootPosition = root.Position + Vector3.new(0, HEIGHT_OFFSET, 0)
-            local cameraPosition = Vector3.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
+            local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
+            local cameraPosition = vector.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
             camera.CFrame = CFrame.lookAt(cameraPosition, rootPosition)
         end
     end
@@ -211,8 +211,8 @@ The last step is to run this function repeatedly to keep the camera in sync with
        if character then
            local root = character:FindFirstChild("HumanoidRootPart")
            if root then
-               local rootPosition = root.Position + Vector3.new(0, HEIGHT_OFFSET, 0)
-               local cameraPosition = Vector3.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
+               local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
+               local cameraPosition = vector.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
                camera.CFrame = CFrame.lookAt(cameraPosition, rootPosition)
            end
        end
@@ -241,8 +241,8 @@ The basic structure of getting the user's position and updating the camera's pos
        if character then
            local root = character:FindFirstChild("HumanoidRootPart")
            if root then
-               local rootPosition = root.Position + Vector3.new(0, HEIGHT_OFFSET, 0)
-               local cameraPosition = rootPosition + Vector3.new(CAMERA_DEPTH, CAMERA_DEPTH, CAMERA_DEPTH)
+               local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
+               local cameraPosition = rootPosition + vector.new(CAMERA_DEPTH, CAMERA_DEPTH, CAMERA_DEPTH)
                camera.CFrame = CFrame.lookAt(cameraPosition, rootPosition)
            end
        end

--- a/content/en-us/tutorials/use-case-tutorials/input-and-camera/controlling-the-users-camera.md
+++ b/content/en-us/tutorials/use-case-tutorials/input-and-camera/controlling-the-users-camera.md
@@ -124,7 +124,7 @@ All character models contain a part named **HumanoidRootPart**, which can be use
        if character then
            local root = character:FindFirstChild("HumanoidRootPart")
            if root then
-               local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
+               local rootPosition = root.Position + vector.create(0, HEIGHT_OFFSET, 0)
            end
        end
    end
@@ -150,8 +150,8 @@ local function updateCamera()
     if character then
         local root = character:FindFirstChild("HumanoidRootPart")
         if root then
-            local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
-            local cameraPosition = vector.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
+            local rootPosition = root.Position + vector.create(0, HEIGHT_OFFSET, 0)
+            local cameraPosition = vector.create(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
         end
     end
 end
@@ -176,8 +176,8 @@ local function updateCamera()
     if character then
         local root = character:FindFirstChild("HumanoidRootPart")
         if root then
-            local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
-            local cameraPosition = vector.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
+            local rootPosition = root.Position + vector.create(0, HEIGHT_OFFSET, 0)
+            local cameraPosition = vector.create(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
             camera.CFrame = CFrame.lookAt(cameraPosition, rootPosition)
         end
     end
@@ -211,8 +211,8 @@ The last step is to run this function repeatedly to keep the camera in sync with
        if character then
            local root = character:FindFirstChild("HumanoidRootPart")
            if root then
-               local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
-               local cameraPosition = vector.new(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
+               local rootPosition = root.Position + vector.create(0, HEIGHT_OFFSET, 0)
+               local cameraPosition = vector.create(rootPosition.X, rootPosition.Y, CAMERA_DEPTH)
                camera.CFrame = CFrame.lookAt(cameraPosition, rootPosition)
            end
        end
@@ -241,8 +241,8 @@ The basic structure of getting the user's position and updating the camera's pos
        if character then
            local root = character:FindFirstChild("HumanoidRootPart")
            if root then
-               local rootPosition = root.Position + vector.new(0, HEIGHT_OFFSET, 0)
-               local cameraPosition = rootPosition + vector.new(CAMERA_DEPTH, CAMERA_DEPTH, CAMERA_DEPTH)
+               local rootPosition = root.Position + vector.create(0, HEIGHT_OFFSET, 0)
+               local cameraPosition = rootPosition + vector.create(CAMERA_DEPTH, CAMERA_DEPTH, CAMERA_DEPTH)
                camera.CFrame = CFrame.lookAt(cameraPosition, rootPosition)
            end
        end

--- a/content/en-us/tutorials/use-case-tutorials/physics/creating-moving-objects.md
+++ b/content/en-us/tutorials/use-case-tutorials/physics/creating-moving-objects.md
@@ -286,7 +286,7 @@ To move an assembly using `Class.BasePart.ApplyImpulse|ApplyImpulse`:
 local volume = script.Parent
 
 local function onTouched(other)
-	local impulse = vector.new(0, 2500, 0)
+	local impulse = vector.create(0, 2500, 0)
 	local character = other.Parent
 	local humanoid = character:FindFirstChildWhichIsA("Humanoid")
 	if humanoid and other.Name == "LeftFoot" then

--- a/content/en-us/tutorials/use-case-tutorials/physics/creating-moving-objects.md
+++ b/content/en-us/tutorials/use-case-tutorials/physics/creating-moving-objects.md
@@ -286,7 +286,7 @@ To move an assembly using `Class.BasePart.ApplyImpulse|ApplyImpulse`:
 local volume = script.Parent
 
 local function onTouched(other)
-	local impulse = Vector3.new(0, 2500, 0)
+	local impulse = vector.new(0, 2500, 0)
 	local character = other.Parent
 	local humanoid = character:FindFirstChildWhichIsA("Humanoid")
 	if humanoid and other.Name == "LeftFoot" then

--- a/content/en-us/tutorials/use-case-tutorials/physics/creating-spinning-objects.md
+++ b/content/en-us/tutorials/use-case-tutorials/physics/creating-spinning-objects.md
@@ -288,7 +288,7 @@ To spin an assembly using `Class.BasePart.ApplyAngularImpulse|ApplyAngularImpuls
 ``` lua
 
 local part = script.Parent
-local impulse = Vector3.new(0, math.random(0, 100), 0)
+local impulse = vector.new(0, math.random(0, 100), 0)
 part:ApplyAngularImpulse(impulse)
 
 ```

--- a/content/en-us/tutorials/use-case-tutorials/physics/creating-spinning-objects.md
+++ b/content/en-us/tutorials/use-case-tutorials/physics/creating-spinning-objects.md
@@ -288,7 +288,7 @@ To spin an assembly using `Class.BasePart.ApplyAngularImpulse|ApplyAngularImpuls
 ``` lua
 
 local part = script.Parent
-local impulse = vector.new(0, math.random(0, 100), 0)
+local impulse = vector.create(0, math.random(0, 100), 0)
 part:ApplyAngularImpulse(impulse)
 
 ```

--- a/content/en-us/tutorials/use-case-tutorials/scripting/intermediate-scripting/hit-detection-with-lasers.md
+++ b/content/en-us/tutorials/use-case-tutorials/scripting/intermediate-scripting/hit-detection-with-lasers.md
@@ -442,7 +442,7 @@ Now that you know where to create a laser beam, you need to add the beam itself.
 
 2. Set the following properties of `laserPart`:
 
-   1. **Size**: vector.new(0.2, 0.2, laserDistance)
+   1. **Size**: vector.create(0.2, 0.2, laserDistance)
    2. **CFrame**: laserCFrame
    3. **Anchored**: true
    4. **CanCollide**: false
@@ -461,7 +461,7 @@ Now that you know where to create a laser beam, you need to add the beam itself.
    	local laserCFrame = CFrame.lookAt(startPosition, endPosition) * CFrame.new(0, 0, -laserDistance / 2)
 
    	local laserPart = Instance.new("Part")
-   	laserPart.Size = vector.new(0.2, 0.2, laserDistance)
+   	laserPart.Size = vector.create(0.2, 0.2, laserDistance)
    	laserPart.CFrame = laserCFrame
    	laserPart.Anchored = true
    	laserPart.CanCollide = false
@@ -1063,7 +1063,7 @@ function LaserRenderer.createLaser(toolHandle, endPosition)
 	local laserCFrame = CFrame.lookAt(startPosition, endPosition) * CFrame.new(0, 0, -laserDistance / 2)
 
 	local laserPart = Instance.new("Part")
-	laserPart.Size = vector.new(0.2, 0.2, laserDistance)
+	laserPart.Size = vector.create(0.2, 0.2, laserDistance)
 	laserPart.CFrame = laserCFrame
 	laserPart.Anchored = true
 	laserPart.CanCollide = false

--- a/content/en-us/tutorials/use-case-tutorials/scripting/intermediate-scripting/hit-detection-with-lasers.md
+++ b/content/en-us/tutorials/use-case-tutorials/scripting/intermediate-scripting/hit-detection-with-lasers.md
@@ -442,7 +442,7 @@ Now that you know where to create a laser beam, you need to add the beam itself.
 
 2. Set the following properties of `laserPart`:
 
-   1. **Size**: Vector3.new(0.2, 0.2, laserDistance)
+   1. **Size**: vector.new(0.2, 0.2, laserDistance)
    2. **CFrame**: laserCFrame
    3. **Anchored**: true
    4. **CanCollide**: false
@@ -461,7 +461,7 @@ Now that you know where to create a laser beam, you need to add the beam itself.
    	local laserCFrame = CFrame.lookAt(startPosition, endPosition) * CFrame.new(0, 0, -laserDistance / 2)
 
    	local laserPart = Instance.new("Part")
-   	laserPart.Size = Vector3.new(0.2, 0.2, laserDistance)
+   	laserPart.Size = vector.new(0.2, 0.2, laserDistance)
    	laserPart.CFrame = laserCFrame
    	laserPart.Anchored = true
    	laserPart.CanCollide = false
@@ -1063,7 +1063,7 @@ function LaserRenderer.createLaser(toolHandle, endPosition)
 	local laserCFrame = CFrame.lookAt(startPosition, endPosition) * CFrame.new(0, 0, -laserDistance / 2)
 
 	local laserPart = Instance.new("Part")
-	laserPart.Size = Vector3.new(0.2, 0.2, laserDistance)
+	laserPart.Size = vector.new(0.2, 0.2, laserDistance)
 	laserPart.CFrame = laserCFrame
 	laserPart.Anchored = true
 	laserPart.CanCollide = false

--- a/content/en-us/ui/3D-drag-detectors.md
+++ b/content/en-us/ui/3D-drag-detectors.md
@@ -406,7 +406,7 @@ local function snapToWorldGrid(proposedMotion)
 	local roundedX = math.floor(newWorldPosition.X / snapIncrement + 0.5) * snapIncrement
 	local roundedY = math.floor(newWorldPosition.Y / snapIncrement + 0.5) * snapIncrement
 	local roundedZ = math.floor(newWorldPosition.Z / snapIncrement + 0.5) * snapIncrement
-	local newRoundedWorldPosition = vector.new(roundedX, roundedY, roundedZ)
+	local newRoundedWorldPosition = vector.create(roundedX, roundedY, roundedZ)
 	return proposedMotion.Rotation + (newRoundedWorldPosition - startPartPosition)
 end
 
@@ -453,7 +453,7 @@ local emitter = script.Parent.EmitterPart.ParticleEmitter
 local dragDetector = slider.DragDetector
 dragDetector.ReferenceInstance = originPart
 dragDetector.MinDragTranslation = vector.zero
-dragDetector.MaxDragTranslation = vector.new(10, 0, 10)
+dragDetector.MaxDragTranslation = vector.create(10, 0, 10)
 
 local dragRangeX = dragDetector.MaxDragTranslation.X - dragDetector.MinDragTranslation.X
 local dragRangeZ = dragDetector.MaxDragTranslation.Z - dragDetector.MinDragTranslation.Z

--- a/content/en-us/ui/3D-drag-detectors.md
+++ b/content/en-us/ui/3D-drag-detectors.md
@@ -343,7 +343,7 @@ If you set a detector's `Class.DragDetector.DragStyle|DragStyle` to **Scriptable
 local dragDetector = script.Parent.DragDetector
 dragDetector.DragStyle = Enum.DragDetectorDragStyle.Scriptable
 
-local cachedHitPoint = Vector3.zero
+local cachedHitPoint = vector.zero
 local cachedHitNormal = Vector3.yAxis
 
 local function followTheCursor(cursorRay)
@@ -352,7 +352,7 @@ local function followTheCursor(cursorRay)
 	raycastParams.FilterDescendantsInstances = {dragDetector.Parent}
 	raycastParams.FilterType = Enum.RaycastFilterType.Exclude
 
-	local hitPoint = Vector3.zero
+	local hitPoint = vector.zero
 	local hitNormal = Vector3.yAxis
 
 	local raycastResult = workspace:Raycast(cursorRay.Origin, cursorRay.Direction, raycastParams)
@@ -406,7 +406,7 @@ local function snapToWorldGrid(proposedMotion)
 	local roundedX = math.floor(newWorldPosition.X / snapIncrement + 0.5) * snapIncrement
 	local roundedY = math.floor(newWorldPosition.Y / snapIncrement + 0.5) * snapIncrement
 	local roundedZ = math.floor(newWorldPosition.Z / snapIncrement + 0.5) * snapIncrement
-	local newRoundedWorldPosition = Vector3.new(roundedX, roundedY, roundedZ)
+	local newRoundedWorldPosition = vector.new(roundedX, roundedY, roundedZ)
 	return proposedMotion.Rotation + (newRoundedWorldPosition - startPartPosition)
 end
 
@@ -452,8 +452,8 @@ local emitter = script.Parent.EmitterPart.ParticleEmitter
 
 local dragDetector = slider.DragDetector
 dragDetector.ReferenceInstance = originPart
-dragDetector.MinDragTranslation = Vector3.zero
-dragDetector.MaxDragTranslation = Vector3.new(10, 0, 10)
+dragDetector.MinDragTranslation = vector.zero
+dragDetector.MaxDragTranslation = vector.new(10, 0, 10)
 
 local dragRangeX = dragDetector.MaxDragTranslation.X - dragDetector.MinDragTranslation.X
 local dragRangeZ = dragDetector.MaxDragTranslation.Z - dragDetector.MinDragTranslation.Z

--- a/content/en-us/ui/video-frames.md
+++ b/content/en-us/ui/video-frames.md
@@ -65,9 +65,9 @@ If you want to play a video in your experience with code, paste the following co
 
 ```lua
 local screenPart = Instance.new("Part")
-screenPart.Size = vector.new(16, 9, 1)
-screenPart.Position = vector.new(0, 8, -20)
-screenPart.Orientation = vector.new(0, 180, 0)
+screenPart.Size = vector.create(16, 9, 1)
+screenPart.Position = vector.create(0, 8, -20)
+screenPart.Orientation = vector.create(0, 180, 0)
 screenPart.Anchored = true
 screenPart.Parent = workspace
 

--- a/content/en-us/ui/video-frames.md
+++ b/content/en-us/ui/video-frames.md
@@ -65,9 +65,9 @@ If you want to play a video in your experience with code, paste the following co
 
 ```lua
 local screenPart = Instance.new("Part")
-screenPart.Size = Vector3.new(16, 9, 1)
-screenPart.Position = Vector3.new(0, 8, -20)
-screenPart.Orientation = Vector3.new(0, 180, 0)
+screenPart.Size = vector.new(16, 9, 1)
+screenPart.Position = vector.new(0, 8, -20)
+screenPart.Orientation = vector.new(0, 180, 0)
 screenPart.Anchored = true
 screenPart.Parent = workspace
 

--- a/content/en-us/workspace/cframes.md
+++ b/content/en-us/workspace/cframes.md
@@ -44,7 +44,7 @@ Alternatively, you can provide a new `Datatype.Vector3` position to `Datatype.CF
 local redBlock = workspace.RedBlock
 
 -- Create new CFrame
-local newVector3 = vector.new(-2, 2, 4)
+local newVector3 = vector.create(-2, 2, 4)
 local newCFrame = CFrame.new(newVector3)
 
 -- Overwrite redBlock's current CFrame with new CFrame
@@ -85,7 +85,7 @@ local redBlock = workspace.RedBlock
 local blueCube = workspace.BlueCube
 
 -- Create a Vector3 for both the start position and target position
-local startPosition = vector.new(0, 3, 0)
+local startPosition = vector.create(0, 3, 0)
 local targetPosition = blueCube.Position
 
 -- Put the redBlock at 'startPosition' and point its front surface at 'targetPosition'
@@ -110,7 +110,7 @@ To offset an object by a specific number of studs from its current position, add
 ```lua highlight='3'
 local redBlock = workspace.RedBlock
 
-redBlock.CFrame = CFrame.new(redBlock.Position) + vector.new(0, 1.25, 0)
+redBlock.CFrame = CFrame.new(redBlock.Position) + vector.create(0, 1.25, 0)
 ```
 
 <GridContainer numColumns="2">
@@ -130,7 +130,7 @@ You can use the same technique to offset an object from the position of another 
 local redBlock = workspace.RedBlock
 local blueCube = workspace.BlueCube
 
-redBlock.CFrame = CFrame.new(blueCube.Position) + vector.new(0, 2, 0)
+redBlock.CFrame = CFrame.new(blueCube.Position) + vector.create(0, 2, 0)
 ```
 
 <GridContainer numColumns="2">

--- a/content/en-us/workspace/cframes.md
+++ b/content/en-us/workspace/cframes.md
@@ -44,7 +44,7 @@ Alternatively, you can provide a new `Datatype.Vector3` position to `Datatype.CF
 local redBlock = workspace.RedBlock
 
 -- Create new CFrame
-local newVector3 = Vector3.new(-2, 2, 4)
+local newVector3 = vector.new(-2, 2, 4)
 local newCFrame = CFrame.new(newVector3)
 
 -- Overwrite redBlock's current CFrame with new CFrame
@@ -85,7 +85,7 @@ local redBlock = workspace.RedBlock
 local blueCube = workspace.BlueCube
 
 -- Create a Vector3 for both the start position and target position
-local startPosition = Vector3.new(0, 3, 0)
+local startPosition = vector.new(0, 3, 0)
 local targetPosition = blueCube.Position
 
 -- Put the redBlock at 'startPosition' and point its front surface at 'targetPosition'
@@ -110,7 +110,7 @@ To offset an object by a specific number of studs from its current position, add
 ```lua highlight='3'
 local redBlock = workspace.RedBlock
 
-redBlock.CFrame = CFrame.new(redBlock.Position) + Vector3.new(0, 1.25, 0)
+redBlock.CFrame = CFrame.new(redBlock.Position) + vector.new(0, 1.25, 0)
 ```
 
 <GridContainer numColumns="2">
@@ -130,7 +130,7 @@ You can use the same technique to offset an object from the position of another 
 local redBlock = workspace.RedBlock
 local blueCube = workspace.BlueCube
 
-redBlock.CFrame = CFrame.new(blueCube.Position) + Vector3.new(0, 2, 0)
+redBlock.CFrame = CFrame.new(blueCube.Position) + vector.new(0, 2, 0)
 ```
 
 <GridContainer numColumns="2">

--- a/content/en-us/workspace/raycasting.md
+++ b/content/en-us/workspace/raycasting.md
@@ -16,7 +16,7 @@ You can cast a ray with the `Class.WorldRoot:Raycast()` method (`Class.WorldRoot
 
 ```lua title='Basic Raycast' highlight='4'
 local rayOrigin = vector.zero
-local rayDirection = vector.new(0, -100, 0)
+local rayDirection = vector.create(0, -100, 0)
 
 local raycastResult = workspace:Raycast(rayOrigin, rayDirection)
 ```
@@ -58,7 +58,7 @@ When casting a ray, the direction parameter should encompass the desired length 
 
 ```lua title='Raycast Filtering' highlight='4-7,9'
 local rayOrigin = vector.zero
-local rayDirection = vector.new(0, -100, 0)
+local rayDirection = vector.create(0, -100, 0)
 
 local raycastParams = RaycastParams.new()
 raycastParams.FilterDescendantsInstances = {script.Parent}
@@ -138,7 +138,7 @@ You can exempt any `Class.BasePart` from hit detection by setting its `Class.Bas
 
 ```lua title='Raycast Hit Detection' highlight='7-11'
 local rayOrigin = vector.zero
-local rayDirection = vector.new(0, -100, 0)
+local rayDirection = vector.create(0, -100, 0)
 
 local raycastResult = workspace:Raycast(rayOrigin, rayDirection)
 

--- a/content/en-us/workspace/raycasting.md
+++ b/content/en-us/workspace/raycasting.md
@@ -15,8 +15,8 @@ At its most basic level, **raycasting** is the act of sending out an invisible r
 You can cast a ray with the `Class.WorldRoot:Raycast()` method (`Class.WorldRoot:Raycast()|workspace:Raycast()`) from a `Datatype.Vector3` origin in a `Datatype.Vector3` direction.
 
 ```lua title='Basic Raycast' highlight='4'
-local rayOrigin = Vector3.new(0, 0, 0)
-local rayDirection = Vector3.new(0, -100, 0)
+local rayOrigin = vector.zero
+local rayDirection = vector.new(0, -100, 0)
 
 local raycastResult = workspace:Raycast(rayOrigin, rayDirection)
 ```
@@ -57,8 +57,8 @@ When casting a ray, the direction parameter should encompass the desired length 
 </table>
 
 ```lua title='Raycast Filtering' highlight='4-7,9'
-local rayOrigin = Vector3.zero
-local rayDirection = Vector3.new(0, -100, 0)
+local rayOrigin = vector.zero
+local rayDirection = vector.new(0, -100, 0)
 
 local raycastParams = RaycastParams.new()
 raycastParams.FilterDescendantsInstances = {script.Parent}
@@ -137,8 +137,8 @@ You can exempt any `Class.BasePart` from hit detection by setting its `Class.Bas
 </Alert>
 
 ```lua title='Raycast Hit Detection' highlight='7-11'
-local rayOrigin = Vector3.zero
-local rayDirection = Vector3.new(0, -100, 0)
+local rayOrigin = vector.zero
+local rayDirection = vector.new(0, -100, 0)
 
 local raycastResult = workspace:Raycast(rayOrigin, rayDirection)
 

--- a/content/en-us/workspace/streaming.md
+++ b/content/en-us/workspace/streaming.md
@@ -344,7 +344,7 @@ teleportEvent.OnServerEvent:Connect(teleportPlayer)
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local teleportEvent = ReplicatedStorage:WaitForChild("TeleportEvent")
-local teleportTarget = Vector3.new(50, 2, 120)
+local teleportTarget = vector.new(50, 2, 120)
 
 -- Fire the remote event
 teleportEvent:FireServer(teleportTarget)

--- a/content/en-us/workspace/streaming.md
+++ b/content/en-us/workspace/streaming.md
@@ -344,7 +344,7 @@ teleportEvent.OnServerEvent:Connect(teleportPlayer)
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local teleportEvent = ReplicatedStorage:WaitForChild("TeleportEvent")
-local teleportTarget = vector.new(50, 2, 120)
+local teleportTarget = vector.create(50, 2, 120)
 
 -- Fire the remote event
 teleportEvent:FireServer(teleportTarget)


### PR DESCRIPTION
## Introduction
With the introduction of the [Vector RFC](https://rfcs.luau.org/vector-library.html) seen in the [release notes for 650](https://devforum.roblox.com/t/release-notes-for-650/3250394)

## Changes
This PR migrates the documentation of Vector3 references to the new vector library where appropriate. Some references may need changing back due to the change required explained next.

More changes may be needed to make this request make sense to end users. Such as a dedicated page in the documentation for - the new library (Raised in PR #957 ), its application and methods - However this was out of scope for this PR.

This PR also compacts Vector3.new(0, 0, 0) to vector.zero where appropriate.

Please note that I understand that vector hasn't been properly announced yet and so this PR may need to sit for a little bit.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
