### PR TITLE
Add note that xpcall's error handler preserves the trace

### DIFF
--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -757,7 +757,7 @@ functions:
       from the call, after this first result. In case of any error, `xpcall()`
       returns false plus the result from `err`.
 
-      Unlike `Global.LuaGlobals.pcall`, the `err` function preserves the stack
+      Unlike `Global.LuaGlobals.pcall()`, the `err` function preserves the stack
       trace of function `f`, which can be inspected using `Library.debug.info()`
       or `Library.debug.traceback()`.
     parameters:

--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -756,6 +756,10 @@ functions:
       succeeds without errors. In this case, `xpcall()` also returns all results
       from the call, after this first result. In case of any error, `xpcall()`
       returns false plus the result from `err`.
+
+      Unlike `Global.LuaGlobals.pcall`, the `err` function preserves the stack
+      trace of function `f`, which can be inspected using `Library.debug.info()`
+      or `Library.debug.traceback()`.
     parameters:
       - name: f
         type: function


### PR DESCRIPTION
## Changes

Adds a note that xpcall's error handler preserves the stack of the erroring function.

This is useful to know if people are building error handlers and need to know the traceback.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
