### PR TITLE
TextTruncate example and SplitWord documented

### DIFF
--- a/content/en-us/reference/engine/enums/TextTruncate.yaml
+++ b/content/en-us/reference/engine/enums/TextTruncate.yaml
@@ -17,12 +17,22 @@ items:
   - name: AtEnd
     summary: |
       Text is truncated at the end of the text; extra graphemes that cannot fit
-      into the space are replaced with `...`.
+      into the space are replaced with `...`. Word boundaries are respected if possible.
+      Example: If the Control is between -> and <- 
+      ->Long text is truncated at the en<-d of the last complete word
+      The text will look like:
+      Long text is truncated at the...
     value: 1
     tags: []
     deprecation_message: ''
   - name: SplitWord
-    summary: ''
+    summary: |
+      If the end of the line occurs in the middle of a word, the text is truncated inside of that word; extra graphemes that cannot fit
+      into the space are replaced with `...`.
+      Example: If the Control is between -> and <- 
+      ->Long text is truncated at the en<-d of the last complete word
+      The text will look like:
+      Long text is truncated at the en...
     value: 2
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/TextTruncate.yaml
+++ b/content/en-us/reference/engine/enums/TextTruncate.yaml
@@ -27,12 +27,17 @@ items:
     deprecation_message: ''
   - name: SplitWord
     summary: |
-      If the end of the line occurs in the middle of a word, the text is truncated inside of that word; extra graphemes that cannot fit
-      into the space are replaced with `...`.
-      Example: If the Control is between -> and <- 
-      ->Long text is truncated at the en<-d of the last complete word
-      The text will look like:
-      Long text is truncated at the en...
+      If the end of the line occurs in the middle of a word, the text is
+      truncated inside of that word. Extra graphemes that cannot fit into the
+      space are replaced with `...`.
+
+      For example, if the control is between -> and <- like so:
+
+      `->Long text is truncated at the en<-d of the last complete word`
+
+      The text will be:
+
+      `Long text is truncated at the en...`
     value: 2
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/TextTruncate.yaml
+++ b/content/en-us/reference/engine/enums/TextTruncate.yaml
@@ -17,11 +17,16 @@ items:
   - name: AtEnd
     summary: |
       Text is truncated at the end of the text; extra graphemes that cannot fit
-      into the space are replaced with `...`. Word boundaries are respected if possible.
-      Example: If the Control is between -> and <- 
-      ->Long text is truncated at the en<-d of the last complete word
-      The text will look like:
-      Long text is truncated at the...
+      into the space are replaced with `...`. Word boundaries are respected if
+      possible.
+
+      For example, if the control is between -> and <- like so:
+
+      `->Long text is truncated at the en<-d of the last complete word`
+
+      The text will be:
+
+      `Long text is truncated at the...`
     value: 1
     tags: []
     deprecation_message: ''


### PR DESCRIPTION
Added missing documentation and examples to Enum.TextTruncate

## Changes

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

None:
<img width="246" alt="image" src="https://github.com/user-attachments/assets/abb15a94-eaf3-4fae-a88f-3599665f1691" />

AtEnd:
<img width="246" alt="image" src="https://github.com/user-attachments/assets/50028bf2-2d74-4214-a6ab-c50d4e0a417b" />

SplitWord:
<img width="236" alt="image" src="https://github.com/user-attachments/assets/efea0f80-0897-4e4d-9887-eebc1395cdf9" />


## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
