### PR TITLE
Simplify to workspace reference

### DIFF
--- a/content/en-us/production/monetization/immersive-ads.md
+++ b/content/en-us/production/monetization/immersive-ads.md
@@ -334,11 +334,10 @@ For example, the following code sample uses `Class.PolicyService:GetPolicyInfoFo
 ```lua
 local Players = game:GetService("Players")
 local PolicyService = game:GetService("PolicyService")
-local Workspace = game:GetService("Workspace")
 
 local player = Players.LocalPlayer
--- Sample assumes a "Main Portal Template" model exists under Workspace
-local mainPortal = Workspace:WaitForChild("Main Portal Template")
+-- Sample assumes a "Main Portal Template" model exists under workspace
+local mainPortal = workspace:WaitForChild("Main Portal Template")
 
 -- Get the policy info for the user
 	local success, result = pcall(PolicyService.GetPolicyInfoForPlayerAsync, PolicyService, player)

--- a/content/en-us/production/promotion/complying-with-advertising-standards.md
+++ b/content/en-us/production/promotion/complying-with-advertising-standards.md
@@ -92,7 +92,6 @@ If you believe all the content in your experience collectively constitutes an ad
 ```lua
 local Players = game:GetService("Players")
 local PolicyService = game:GetService("PolicyService")
-local Workspace = game:GetService("Workspace")
 
 local player = Players.LocalPlayer
 

--- a/content/en-us/reference/engine/classes/Camera.yaml
+++ b/content/en-us/reference/engine/classes/Camera.yaml
@@ -69,15 +69,13 @@ properties:
       `Datatype.Vector3.new(10, 0, 0)`.
 
       ```lua
-      local Workspace = game:GetService("Workspace")
-
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
       camera.CameraType = Enum.CameraType.Scriptable
 
       local pos = Vector3.new(0, 10, 0)
       local lookAtPos = Vector3.new(10, 0, 0)
 
-      Workspace.CurrentCamera.CFrame = CFrame.lookAt(pos, lookAtPos)
+      workspace.CurrentCamera.CFrame = CFrame.lookAt(pos, lookAtPos)
       ```
 
       Although the camera can be placed in the manner demonstrated above, you
@@ -93,9 +91,8 @@ properties:
         ```lua
         local Players = game:GetService("Players")
         local TweenService = game:GetService("TweenService")
-        local Workspace = game:GetService("Workspace")
 
-        local camera = Workspace.CurrentCamera
+        local camera = workspace.CurrentCamera
         camera.CameraType = Enum.CameraType.Scriptable
 
         local player = Players.LocalPlayer
@@ -149,10 +146,9 @@ properties:
 
       ```lua
       local Players = game:GetService("Players")
-      local Workspace = game:GetService("Workspace")
 
       local localPlayer = Players.LocalPlayer
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local function resetCameraSubject()
       	if camera and localPlayer.Character then
@@ -378,9 +374,8 @@ properties:
 
       ```lua
       local UserInputService = game:GetService("UserInputService")
-      local Workspace = game:GetService("Workspace")
 
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local headCFrame = UserInputService:GetUserCFrame(Enum.UserCFrame.Head)
       headCFrame = headCFrame.Rotation + headCFrame.Position * camera.HeadScale
@@ -710,9 +705,7 @@ methods:
       should opt for the `Class.WorldRoot:Raycast()` method.
 
       ```lua
-      local Workspace = game:GetService("Workspace")
-
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local castPoints = {
       	Vector3.new(0, 10, 0),
@@ -767,9 +760,8 @@ methods:
 
       ```lua
       local UserInputService = game:GetService("UserInputService")
-      local Workspace = game:GetService("Workspace")
 
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local headCFrame = UserInputService:GetUserCFrame(Enum.UserCFrame.Head)
       headCFrame = headCFrame.Rotation + headCFrame.Position * camera.HeadScale
@@ -1007,9 +999,7 @@ methods:
       create a longer ray, you can do the following:
 
       ```lua
-      local Workspace = game:GetService("Workspace")
-
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
       local length = 500
       local unitRay = camera:ScreenPointToRay(100, 100)
       local extendedRay = Ray.new(unitRay.Origin, unitRay.Direction * length)
@@ -1216,9 +1206,7 @@ methods:
       centre of the screen, for example:
 
       ```lua
-      local Workspace = game:GetService("Workspace")
-
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local viewportPoint = camera.ViewportSize / 2
       local unitRay = camera:ViewportPointToRay(viewportPoint.X, viewportPoint.Y, 0)
@@ -1228,9 +1216,7 @@ methods:
       create a longer ray, you can do the following:
 
       ```lua
-      local Workspace = game:GetService("Workspace")
-
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local length = 500
       local unitRay = camera:ScreenPointToRay(100, 100)
@@ -1287,9 +1273,7 @@ methods:
       `Class.Camera:WorldToViewportPoint()|WorldToViewportPoint()`.
 
       ```lua
-      local Workspace = game:GetService("Workspace")
-
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local worldPoint = Vector3.new(0, 10, 0)
       local vector, onScreen = camera:WorldToScreenPoint(worldPoint)
@@ -1346,9 +1330,7 @@ methods:
       `Class.Camera:WorldToScreenPoint()|WorldToScreenPoint()`.
 
       ```lua
-      local Workspace = game:GetService("Workspace")
-
-      local camera = Workspace.CurrentCamera
+      local camera = workspace.CurrentCamera
 
       local worldPoint = Vector3.new(0, 10, 0)
       local vector, onScreen = camera:WorldToViewportPoint(worldPoint)

--- a/content/en-us/reference/engine/classes/MeshPart.yaml
+++ b/content/en-us/reference/engine/classes/MeshPart.yaml
@@ -235,9 +235,7 @@ properties:
       applied to the mesh.
 
       ```
-      local Workspace = game:GetService("Workspace")
-
-      local meshPart = Workspace.MeshPart
+      local meshPart = workspace.MeshPart
       meshPart.TextureContent = Content.none  -- No texture
       ```
 
@@ -263,9 +261,8 @@ properties:
 
       ```
       local AssetService = game:GetService("AssetService")
-      local Workspace = game:GetService("Workspace")
 
-      local meshPart = Workspace.MeshPart
+      local meshPart = workspace.MeshPart
 
       local editableImage = AssetService:CreateEditableImageAsync(meshPart.TextureContent)
       meshPart.TextureContent = Content.fromObject(editableImage)  -- Live updates
@@ -309,9 +306,7 @@ properties:
       to the mesh.
 
       ```
-      local Workspace = game:GetService("Workspace")
-
-      local meshPart = Workspace.MeshPart
+      local meshPart = workspace.MeshPart
       meshPart.TextureID = ""  -- No texture
       ```
 

--- a/content/en-us/studio/microprofiler/using-microprofiler.md
+++ b/content/en-us/studio/microprofiler/using-microprofiler.md
@@ -61,7 +61,7 @@ Now that the MicroProfiler has provided a starting point, you can troubleshoot t
    		local endPosition = getRandomPosition()
    		local direction = endPosition - startPosition
 
-   		Workspace:Raycast(
+   		workspace:Raycast(
             startPosition,
             endPosition
          )
@@ -86,7 +86,7 @@ Now that the MicroProfiler has provided a starting point, you can troubleshoot t
          local endPosition = getRandomPosition()
          local direction = endPosition - startPosition
 
-         Workspace:Raycast(
+         workspace:Raycast(
             startPosition,
             endPosition
          )

--- a/content/en-us/tutorials/curriculums/core/scripting/create-player-hazards.md
+++ b/content/en-us/tutorials/curriculums/core/scripting/create-player-hazards.md
@@ -52,9 +52,8 @@ To create the basic water hazard:
 
    ```lua
    local Players = game:GetService("Players")
-   local Workspace = game:GetService("Workspace")
 
-   local hazardsFolder = Workspace.World.Hazards
+   local hazardsFolder = workspace.World.Hazards
    local hazards = hazardsFolder:GetChildren()
 
    local function onHazardTouched(otherPart)

--- a/content/en-us/tutorials/curriculums/core/scripting/record-and-display-player-data.md
+++ b/content/en-us/tutorials/curriculums/core/scripting/record-and-display-player-data.md
@@ -295,7 +295,6 @@ data. To update **CoinService**:
 
     ```lua
     -- Initializing services and variables
-    local Workspace = game:GetService("Workspace")
     local Players = game:GetService("Players")
     local ServerStorage = game:GetService("ServerStorage")
 
@@ -303,7 +302,7 @@ data. To update **CoinService**:
     local Leaderboard = require(ServerStorage.Leaderboard)
     local PlayerData = require(ServerStorage.PlayerData)
 
-    local coinsFolder = Workspace.World.Coins
+    local coinsFolder = workspace.World.Coins
     local coins = coinsFolder:GetChildren()
 
     local COIN_KEY_NAME = PlayerData.COIN_KEY_NAME

--- a/content/en-us/tutorials/curriculums/core/scripting/script-game-behavior.md
+++ b/content/en-us/tutorials/curriculums/core/scripting/script-game-behavior.md
@@ -68,10 +68,9 @@ which tells the engine to run the script on the server, and prevents clients fro
 
    ```lua
    -- Initializing services and variables
-   local Workspace = game:GetService("Workspace")
    local Players = game:GetService("Players")
 
-   local coinsFolder = Workspace.World.Coins
+   local coinsFolder = workspace.World.Coins
    local coins = coinsFolder:GetChildren()
 
    local COOLDOWN = 10
@@ -129,16 +128,15 @@ which tells the engine to run the script on the server, and prevents clients fro
      workspace for all references to coin objects with the
      `Class.Instance:GetChildren()|GetChildren()` method. This method returns an
      array containing everything parented to the object it's associated with,
-     which in this case is the `Workspace.World.Coins` folder you created
+     which in this case is the `workspace.World.Coins` folder you created
      previously.
    - **Defines a global variable** - The `COOLDOWN` variable is used later to
      define how long to disable a coin after it's collected.
 
      ```lua title="Initializing Services and Variables"
-     local Workspace = game:GetService("Workspace")
      local Players = game:GetService("Players")
 
-     local coinsFolder = Workspace.World.Coins
+     local coinsFolder = workspace.World.Coins
      local coins = coinsFolder:GetChildren()
 
      local COOLDOWN = 10

--- a/content/en-us/tutorials/curriculums/user-interface-design/implement-designs-in-studio.md
+++ b/content/en-us/tutorials/curriculums/user-interface-design/implement-designs-in-studio.md
@@ -1920,7 +1920,6 @@ The following `ReplicatedStorage.FirstPersonBlasterVisuals` client script handle
 ``` lua
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local Workspace = game:GetService("Workspace")
 local RunService = game:GetService("RunService")
 
 local BlastData = require(ReplicatedStorage.Blaster.BlastData)
@@ -1938,7 +1937,7 @@ local laserBlastedBindableEvent = ReplicatedStorage.Instances.LaserBlastedBindab
 local RIG_OFFSET_FROM_CAMERA = CFrame.new(2, -2, -3) * CFrame.Angles(math.rad(0.25), math.rad(95.25), 0)
 
 local localPlayer = Players.LocalPlayer
-local currentCamera = Workspace.CurrentCamera
+local currentCamera = workspace.CurrentCamera
 
 local rigModel = nil
 local cooldownBar = nil
@@ -1949,7 +1948,7 @@ local function addFirstPersonVisuals()
 
 	-- Add the first person rig
 	rigModel = blasterConfig.RigModel:Clone()
-	rigModel.Parent = Workspace
+	rigModel.Parent = workspace
 
 	-- Add the cooldownBar
 	cooldownBar = addCooldownBar(rigModel.PrimaryPart.CooldownBarAttachment)

--- a/content/en-us/tutorials/use-case-tutorials/animation/playing-character-animations.md
+++ b/content/en-us/tutorials/use-case-tutorials/animation/playing-character-animations.md
@@ -216,13 +216,11 @@ To create a local script that will detect when the local player's character touc
 1. In the new script, paste the following code:
 
    ```lua
-   local Workspace = game:GetService("Workspace")
-
    local animation = script:WaitForChild("Animation")
    local humanoid = script.Parent:WaitForChild("Humanoid")
    local animator = humanoid:WaitForChild("Animator")
    local animationTrack = animator:LoadAnimation(animation)
-   local animationDetector = Workspace:WaitForChild("AnimationDetector")
+   local animationDetector = workspace:WaitForChild("AnimationDetector")
 
    local debounce = false
 
@@ -249,7 +247,7 @@ To create a local script that will detect when the local player's character touc
 </AccordionSummary>
 <AccordionDetails>
 
-The `TriggerAnimation` script starts by getting the `Class.Workspace` service, which contains all objects that exist in the 3D world. This is important because the script needs to reference the `Class.Part` object acting as your volume.
+The `TriggerAnimation` script starts by setting variables for the Humanoid and necessary animation references. This is important because the script needs to reference these later.
 
 For each player character that loads or respawns back into the experience, the script waits for:
 

--- a/content/en-us/tutorials/use-case-tutorials/ui/creating-hud-meters.md
+++ b/content/en-us/tutorials/use-case-tutorials/ui/creating-hud-meters.md
@@ -598,7 +598,6 @@ The default health meter system includes a brief, subtle red tint on the screen 
 2. Select all lines and paste over them with the following code:
 
 		```lua title='UpdateCustomMeter'
-		local Workspace = game:GetService("Workspace")
 		local Players = game:GetService("Players")
 		local TweenService = game:GetService("TweenService")
 
@@ -614,7 +613,7 @@ The default health meter system includes a brief, subtle red tint on the screen 
 		local cachedHealth = humanoid.Health / humanoid.MaxHealth
 
 		-- Get (or create new) color correction effect inside player camera
-		local colorCorrection = Workspace.CurrentCamera:FindFirstChildWhichIsA("ColorCorrectionEffect") or Instance.new("ColorCorrectionEffect", Workspace.CurrentCamera)
+		local colorCorrection = workspace.CurrentCamera:FindFirstChildWhichIsA("ColorCorrectionEffect") or Instance.new("ColorCorrectionEffect", workspace.CurrentCamera)
 		colorCorrection.Name = "DamageColorEffect"
 
 		-- Reference to meter bar inner frame


### PR DESCRIPTION
## Changes

The current documentation regularly reference different ways of getting workspace. This PR simplifies all the references of getting workspace to accessing the global variable workspace. The aim of this is to reduce lines of code in examples by not needing to store an extra variable which also hopefully simplifies the code for new learners.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
