### PR TITLE
Fix error message type

### DIFF
--- a/content/en-us/reference/engine/globals/LuaGlobals.yaml
+++ b/content/en-us/reference/engine/globals/LuaGlobals.yaml
@@ -95,7 +95,7 @@ functions:
       position information to the message.
     parameters:
       - name: message
-        type: string
+        type: Variant
         default:
         summary: |
           The error message to display.


### PR DESCRIPTION
## Changes

Error's Luau type def is `<T>(message: T, level: number): never`, not `(message: string, level: number): never`. It works as expected by throwing the passed object instead of a string. I haven't updated the summary text as this is (mostly) correct.

![image](https://github.com/user-attachments/assets/f93fabdb-d533-4090-aa8f-7a3b79d894a2)

![image](https://github.com/user-attachments/assets/e146f215-7a4e-4c01-a102-af16f24fed68)


## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
