### PR TITLE
Additional clarification on GuiBase2d.AbsolutePosition

### DIFF
--- a/content/en-us/reference/engine/classes/GuiBase2d.yaml
+++ b/content/en-us/reference/engine/classes/GuiBase2d.yaml
@@ -25,7 +25,8 @@ properties:
       in pixels. This represents the actual pixel position at which an element
       renders as a result of its ancestors' sizes and positions. Note that the
       object's `Class.GuiObject.AnchorPoint|AnchorPoint` influences
-      `Class.GuiBase2d.AbsolutePosition|AbsolutePosition`.
+      `Class.GuiBase2d.AbsolutePosition|AbsolutePosition`, but it will always
+      represent the top-left corner of the `Class.GuiBase2d` element.
 
       See also `Class.GuiBase2d.AbsoluteRotation|AbsoluteRotation` and
       `Class.GuiBase2d.AbsoluteSize|AbsoluteSize`.


### PR DESCRIPTION
## Changes
To avoid potentially misleading vagueness, this PR makes minor changes to the note's wording within the description of the `AbsolutePosition` property of `GuiBase2d` elements. Clarification that the property will always represent the top-left corner of a `GuiBase2d`, regardless of the ambiguous "influences" `AnchorPoint` has on the `AbsolutePosition`.

## Checks
By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
