### PR TITLE
Update TextChatCommand.yaml to specify folder requirement

### DIFF
--- a/content/en-us/reference/engine/classes/TextChatCommand.yaml
+++ b/content/en-us/reference/engine/classes/TextChatCommand.yaml
@@ -6,7 +6,7 @@ summary: |
   Represents a text chat command.
 description: |
   Represents a text chat command. Can be used to create custom text chat
-  commands when parented to the `TextChatCommands` folder inside
+  commands when parented to the `TextChatCommands|no-link` folder inside
   `Class.TextChatService`. Custom commands can have up to two aliases,
   and the Triggered event fires when a user types "/{PrimaryAlias}" or
   "/{SecondaryAlias}" into the chat.

--- a/content/en-us/reference/engine/classes/TextChatCommand.yaml
+++ b/content/en-us/reference/engine/classes/TextChatCommand.yaml
@@ -6,9 +6,10 @@ summary: |
   Represents a text chat command.
 description: |
   Represents a text chat command. Can be used to create custom text chat
-  commands when parented to `Class.TextChatService`. Custom commands can have up
-  to two aliases, and the Triggered event fires when a user types
-  "/{PrimaryAlias}" or "/{SecondaryAlias}" into the chat.
+  commands when parented to the `TextChatCommands` folder inside
+  `Class.TextChatService`. Custom commands can have up to two aliases,
+  and the Triggered event fires when a user types "/{PrimaryAlias}" or
+  "/{SecondaryAlias}" into the chat.
 
   To learn more about using `Class.TextChatService`, see
   [In-Experience Text Chat](../../../chat/in-experience-text-chat.md).


### PR DESCRIPTION
## Changes

Clarified that `TextChatCommand`s must be parented under the folder named `TextChatCommands` within `TextChatService` in order to work, instead of just parented to the service.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
