### PR TITLE
Add link to MemoryStoreHashMap documentation for easier access

### DIFF
--- a/content/en-us/cloud-services/memory-stores/hash-map.md
+++ b/content/en-us/cloud-services/memory-stores/hash-map.md
@@ -54,6 +54,8 @@ After you get a hash map, call any of the following functions to read or write d
 </tbody>
 </table>
 
+For more in depth documentation about each function, see `Class.MemoryStoreHashMap`.
+
 <Alert severity="warning">
 All functions accessing data structures in memory stores are asynchronous network calls that might occasionally fail. You should wrap these calls in `Global.LuaGlobals.pcall()` to catch and handle errors, as shown in the code samples.
 </Alert>

--- a/content/en-us/cloud-services/memory-stores/hash-map.md
+++ b/content/en-us/cloud-services/memory-stores/hash-map.md
@@ -54,7 +54,7 @@ After you get a hash map, call any of the following functions to read or write d
 </tbody>
 </table>
 
-For more in depth documentation about each function, see `Class.MemoryStoreHashMap`.
+For in-depth documentation about each function, see `Class.MemoryStoreHashMap`.
 
 <Alert severity="warning">
 All functions accessing data structures in memory stores are asynchronous network calls that might occasionally fail. You should wrap these calls in `Global.LuaGlobals.pcall()` to catch and handle errors, as shown in the code samples.


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
While working with MemoryStoreHashMap, I noticed there wasn't a direct link to its documentation. To improve accessibility, I added a link directly below the function explanations. This addition aims to make it easier for users to find detailed information, such as parameter descriptions, without having to search separately.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
