### PR TITLE
Update HttpService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/HttpService.yaml
+++ b/content/en-us/reference/engine/classes/HttpService.yaml
@@ -456,6 +456,71 @@ methods:
           </tbody>
       </table>
 
+      #### HTTP Methods
+
+      The HTTP request methods specify the purpose of the request being made and what is expected if the request is successful. 
+      For instance: The [`GET`](https://developer.mozilla.org/docs/Web/HTTP/Methods/GET) request method tells the server at the requested address that a resource is being requested and if 
+      it succeeds, the resource at that address will be returned. Similarly, the [`HEAD`](https://developer.mozilla.org/docs/Web/HTTP/Methods/HEAD) request method does the same except the 
+      server knows to return a response without a `Body` element.
+
+      <table>
+          <thead>
+              <tr>
+                  <th>Method</th>
+                  <th>Description</th>
+                  <th>Supported</th>
+                  <th>Safe</th>
+              </tr>
+          </thead>
+          <tbody>
+              <tr>
+                  <td><b>[`GET`](https://developer.mozilla.org/docs/Web/HTTP/Methods/GET)</b></td>
+                  <td>The `GET` method requests the resource at the specified address. Does not support use of the `Body` parameter.</td>
+                  <td>Yes</td>
+              </tr>
+              <tr>
+                  <td><b>[`HEAD`](https://developer.mozilla.org/docs/Web/HTTP/Methods/HEAD)</b></td>
+                  <td>The `HEAD` method requests a response identical to a `GET` request, but with no response body. Does not support use of the `Body` parameter.</td>
+                  <td>Yes</td>
+              </tr>
+              <tr>
+                  <td><b>[`POST`](https://developer.mozilla.org/docs/Web/HTTP/Methods/POST)</b></td>
+                  <td>The `POST` method submits the supplied `Body` data to the requested address.</td>
+                  <td>Yes</td>
+              </tr>
+              <tr>
+                  <td><b>[`PUT`](https://developer.mozilla.org/docs/Web/HTTP/Methods/PUT)</b></td>
+                  <td>The `PUT` method replaces all current iterations of the resource specified within the supplied `Body` data.</td>
+                  <td>Yes</td>
+              </tr>
+              <tr>
+                  <td><b>[`DELETE`](https://developer.mozilla.org/docs/Web/HTTP/Methods/DELETE)</b></td>
+                  <td>The `DELETE` method deletes the resource specified in the supplied `Body` data at the requested address.</td>
+                  <td>Yes</td>
+              </tr>
+              <tr>
+                  <td><b>[`CONNECT`](https://developer.mozilla.org/docs/Web/HTTP/Methods/CONNECT)</b></td>
+                  <td>The `CONNECT` method establishes a tunnel to the requested server identified with the supplied `Body` data.</td>
+                  <td>No</td>
+              </tr>
+              <tr>
+                  <td><b>[`OPTIONS`](https://developer.mozilla.org/docs/Web/HTTP/Methods/OPTIONS)</b></td>
+                  <td>The `OPTIONS` method requests the permitted communication options for the supplied address.</td>
+                  <td>Yes</td>
+              </tr>
+              <tr>
+                  <td><b>[`TRACE`](https://developer.mozilla.org/docs/Web/HTTP/Methods/TRACE)</b></td>
+                  <td>The `TRACE` method performs a message loop-back test along the path to the resource specified in the supplied `Body` data.</td>
+                  <td>Yes</td>
+              </tr>
+              <tr>
+                  <td><b>[`PATCH`](https://developer.mozilla.org/docs/Web/HTTP/Methods/PATCH)</b></td>
+                  <td>The `PATCH` method applies partial changes to the resource specified in the supplied `Body` data at the requested address.</td>
+                  <td>Yes</td>
+              </tr>
+          </tbody>
+      </table>
+
       #### HTTP Headers
 
       In the request dictionary, you can specify custom HTTP headers to use in


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

Added information for HTTP methods, what each of them are, and if they are currently supported by Roblox's HTTPService.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

Connect is the only method not currently supported. This is likely because it creates an information tunnel between the target server and the server requesting the connection. I can provide the code I used to test each of the methods, but it's just a pretty simple express server and Roblox script. I'll make a feature request for the Connect method but I think its pretty unlikely that will ever get added.

I also don't know if it's a problem that I linked 3rd party sources (Mozilla Docs), but Roblox doesn't have pages for the individual HTTP methods and I don't believe it would make sense to add individual pages for them as it entirely relates to the HTTPService. 

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
