### PR TITLE
Fix hotkey for swapping between Move and Rotate moves in AnimationEditor doc

### DIFF
--- a/content/en-us/animation/editor.md
+++ b/content/en-us/animation/editor.md
@@ -224,9 +224,7 @@ To create a pose:
 
    <Alert severity="info" variant="standard">
    When creating poses, you can toggle between **Move** and **Rotate**
-   modes by pressing <kbd>Ctrl</kbd><kbd>2</kbd> or <kbd>Ctrl</kbd><kbd>4</kbd>,
-   respectively (<kbd>⌘</kbd><kbd>2</kbd> or <kbd>⌘</kbd><kbd>4</kbd>
-   on Mac). These modes work exactly like moving and rotating base objects, including the snap settings and incremental values located in the **Snap to Grid** section of the **Model** tab.
+   modes by pressing <kbd>R</kbd>. These modes work exactly like moving and rotating base objects, including the snap settings and incremental values located in the **Snap to Grid** section of the **Model** tab.
    </Alert>
 
 5. Continue moving or rotating bones or meshes until you get the desired pose.


### PR DESCRIPTION
## Changes

Fixes out dated entry in Animation editor. The hotkey for swapping between Move and Rotate has changed from `ctrl+2` / `ctrl+4` to just `R`. This devforum post confirms it (works for me locally as well): https://devforum.roblox.com/t/how-do-you-switch-to-the-movement-mode-in-the-animation-editor/1791442

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
