### PR TITLE
Fixed minor grammar mistake in metatables.md

### DIFF
--- a/content/en-us/luau/metatables.md
+++ b/content/en-us/luau/metatables.md
@@ -80,7 +80,7 @@ Here's the list of available metamethods:
 		</tr>
 	  <tr>
 		  <td>__mul(table, value)</td>
-		  <td>The * mulitplication operator.</td>
+		  <td>The * multiplication operator.</td>
 		</tr>
 	  <tr>
 		  <td>__div(table, value)</td>


### PR DESCRIPTION
## Changes
Fixed a minor grammar mistake found in the word multiplication for the description of the `__mul` metamethod in the documentation of Metatables. Corrected word from "mulitplication" to multiplication.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
