### PR TITLE
fix: TextColor3 default value

### DIFF
--- a/content/en-us/reference/engine/classes/ChatWindowMessageProperties.yaml
+++ b/content/en-us/reference/engine/classes/ChatWindowMessageProperties.yaml
@@ -100,7 +100,7 @@ properties:
       Stroke color applied to text in the chat window.
     description: |
       Determines the stroke color applied to text in the chat window. Default
-      value is `Datatype.Color3.new(0, 0, 0)` (black).
+      value is `Datatype.Color3.fromRGB(0, 0, 0)` (black).
     code_samples: []
     type: Color3
     tags: []

--- a/content/en-us/reference/engine/classes/ChatWindowMessageProperties.yaml
+++ b/content/en-us/reference/engine/classes/ChatWindowMessageProperties.yaml
@@ -59,7 +59,7 @@ properties:
       Color of the text in the chat window.
     description: |
       Determines the color of the text in the chat window. Default value is
-      `Datatype.Color3.new(255, 255, 255)` (white).
+      `Datatype.Color3.new(1, 1, 1)` (white).
     code_samples: []
     type: Color3
     tags: []

--- a/content/en-us/reference/engine/classes/ChatWindowMessageProperties.yaml
+++ b/content/en-us/reference/engine/classes/ChatWindowMessageProperties.yaml
@@ -59,7 +59,7 @@ properties:
       Color of the text in the chat window.
     description: |
       Determines the color of the text in the chat window. Default value is
-      `Datatype.Color3.new(1, 1, 1)` (white).
+      `Datatype.Color3.fromRGB(255, 255, 255)` (white).
     code_samples: []
     type: Color3
     tags: []


### PR DESCRIPTION
## Changes

Corrects the incorrect use of `Color3.new`

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
