### PR TITLE
Humanoid:ChangeState() description update

### DIFF
--- a/content/en-us/reference/engine/classes/Humanoid.yaml
+++ b/content/en-us/reference/engine/classes/Humanoid.yaml
@@ -1438,6 +1438,11 @@ methods:
         `Enum.HumanoidStateType.PlatformStanding` will cause the humanoid state
         to be automatically set to `Enum.HumanoidStateType.Running`.
 
+      Note that in order to set the `Class.Humanoid` state using this function, 
+      you must do it in a `Class.LocalScript` owned by the NetworkOwner of the 
+      `Class.Character`. You can use this function in a `Class.Script`, but the NetworkOwner 
+      of the `Class.Chatacter` must be the Server.
+
       See also `Class.Humanoid:SetStateEnabled()` to enable or disable a
       particular state, and `Class.Humanoid:GetState()` to get the current
       humanoid state.

--- a/content/en-us/reference/engine/classes/Humanoid.yaml
+++ b/content/en-us/reference/engine/classes/Humanoid.yaml
@@ -1441,7 +1441,7 @@ methods:
       Note that in order to set the `Class.Humanoid` state using this function, 
       you must do it in a `Class.LocalScript` owned by the NetworkOwner of the 
       `Class.Character`. You can use this function in a `Class.Script`, but the NetworkOwner 
-      of the `Class.Chatacter` must be the Server.
+      of the `Class.Character` must be the Server.
 
       See also `Class.Humanoid:SetStateEnabled()` to enable or disable a
       particular state, and `Class.Humanoid:GetState()` to get the current

--- a/content/en-us/reference/engine/classes/Humanoid.yaml
+++ b/content/en-us/reference/engine/classes/Humanoid.yaml
@@ -1440,8 +1440,8 @@ methods:
 
       Note that in order to set the `Class.Humanoid` state using this function, 
       you must do it in a `Class.LocalScript` owned by the NetworkOwner of the 
-      `Class.Character`. You can use this function in a `Class.Script`, but the NetworkOwner 
-      of the `Class.Character` must be the Server.
+      `Class.Player.Character`. You can use this function in a `Class.Script`, but the NetworkOwner 
+      of the `Class.Player.Character` must be the Server.
 
       See also `Class.Humanoid:SetStateEnabled()` to enable or disable a
       particular state, and `Class.Humanoid:GetState()` to get the current


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
Updates the ChangeState method description, in order to let the users know that It only works on the NetworkOwner of the character side (If the NetworkOwner is a player, It must be done using a localscript owned by that player. If it's server, must be done in a server script

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
https://devforum.roblox.com/t/can-one-change-the-humanoid-state-from-a-server-script/1131039/8
https://devforum.roblox.com/t/can-one-change-the-humanoid-state-from-a-server-script/1131039/10

## Checks

By submitting your pull request for review, you agree to the following:

- [✅] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [✅] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [✅] To the best of my knowledge, all proposed changes are accurate.
