### PR TITLE
Remove reference to .Changed firing for attribute changes

### DIFF
--- a/content/en-us/scripting/attributes.md
+++ b/content/en-us/scripting/attributes.md
@@ -141,12 +141,6 @@ cabbage:SetAttribute("GrowthRate", nil)
 
 There are several ways to listen for changes to properties and attributes:
 
-- The `Class.Instance.Changed` event listens for changes to any property (including attributes) and passes the name of the changed property as a parameter.
-
-  <Alert severity="info">
-  In the case of attribute changes, `Class.Instance.Changed` fires and passes the string `"Attributes"`, which lets you ignore the event, but isn't especially useful otherwise.
-  </Alert>
-
 - The `Class.Instance.AttributeChanged` event listens for changes to any attribute and passes the name of the changed attribute as a parameter.
 - The `Class.Instance:GetPropertyChangedSignal()` method lets you listen for changes to one property and passes no parameters.
 - The `Class.Instance:GetAttributeChangedSignal()` method lets you listen for changes to one attribute and passes no parameters.


### PR DESCRIPTION
## Changes

This was changed in 653.

https://create.roblox.com/docs/en-us/release-notes/release-notes-653

> Instance.Changed and DataModel.ItemChanged signals will no longer be called when non-scriptable of inaccessible properties change.


## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
