### PR TITLE
Consolidate HttpEnabled explaination

### DIFF
--- a/content/en-us/reference/engine/classes/HttpService.yaml
+++ b/content/en-us/reference/engine/classes/HttpService.yaml
@@ -28,14 +28,8 @@ description: |
 
   ##### Enable HTTP requests
 
-  Request-sending methods aren't enabled by default. To send requests, toggle on
-  **Allow&nbsp;HTTP&nbsp;Requests** through the
-  [Game Settings](../../../studio/game-settings.md) interface in Studio, or set
-  `Class.HttpService.HttpEnabled|HttpEnabled` to `true` in the
-  [Command Bar](../../../studio/ui-overview.md#command-bar) for **unpublished**
-  experiences:
-
-  `game:GetService("HttpService").HttpEnabled = true`
+  Request-sending methods aren't enabled by default. To send requests, you must
+  [enable HTTP requests](#HttpEnabled) for your experience.
 
   ##### Use in plugins
 
@@ -87,9 +81,17 @@ properties:
     summary: |
       Indicates whether HTTP requests can be sent to external websites.
     description: |
-      When set to `true`, you are able to send requests to other websites using
+      When set to `true`, allows scripts to send requests to websites using
       `Class.HttpService:GetAsync()`, `Class.HttpService:PostAsync()`, and
       `Class.HttpService:RequestAsync()`.
+      
+      To send requests, this property must be toggled on through the 
+      [Game Settings](../../../studio/game-settings.md) interface in Studio, or
+      for **unpublished** experiences, set this property to `true` using the
+      [Command Bar](../../../studio/ui-overview.md#command-bar):
+  
+      `game:GetService("HttpService").HttpEnabled = true`
+      
     code_samples:
     type: bool
     tags: []


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
The HttpService page currently provides multiple explainers of HttpEnabled - but none under the HttpEnabled property. I've spoken to a few people who have found this confusing, particularly when being linked into this page and missing the summary at the top (especially given that the sub-heading for 'Enable HTTP requests' does not show on the 'On This Page' right-hand navigation.

This PR consolidates the explanation on the page under the HttpEnabled property, linking down to it from the summary. 

If this PR is merged, then the code samples on this page should also be updated to just link to the HttpEnabled property as a single source-of-truth explainer. For example, the astronaut sample currently contains an explanation that doesn't consider setting with command bar, whilst the Pastebin and RequestAsync samples do not mention enabling requests at all. 
(obviously I can't currently update the samples as they're not present on repo!)

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
