### PR TITLE
Update TextChatService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -311,10 +311,10 @@ methods:
       Determines whether a user has permission to chat in experiences. Factors
       such as parental control settings may prevent the user from sending
       messages. Errors if the userId is not in the current server. Note that
-      this method can be used with all current player userIds in a `Class.Script` 
+      this method can be used with all current player `Class.Player.UserId|UserIds` in a `Class.Script` 
       with `Class.Script.RunContext|RunContext` of `Enum.RunContext.Server` or
-      `Enum.RunContext.Legacy`. In a `Class.LocalScript` this method can be used, 
-      but only with the userId of the local player.
+      `Enum.RunContext.Legacy`. This method can also be used in a `Class.LocalScript` 
+      but only with the `Class.Player.UserId|UserId` of the local player.
     code_samples: []
     parameters:
       - name: userId

--- a/content/en-us/reference/engine/classes/TextChatService.yaml
+++ b/content/en-us/reference/engine/classes/TextChatService.yaml
@@ -311,9 +311,10 @@ methods:
       Determines whether a user has permission to chat in experiences. Factors
       such as parental control settings may prevent the user from sending
       messages. Errors if the userId is not in the current server. Note that
-      this method is only available for use in a `Class.Script` with
-      `Class.Script.RunContext|RunContext` of `Enum.RunContext.Server` or
-      `Enum.RunContext.Legacy`.
+      this method can be used with all current player userIds in a `Class.Script` 
+      with `Class.Script.RunContext|RunContext` of `Enum.RunContext.Server` or
+      `Enum.RunContext.Legacy`. In a `Class.LocalScript` this method can be used, 
+      but only with the userId of the local player.
     code_samples: []
     parameters:
       - name: userId


### PR DESCRIPTION
Fixed an inconsistency with [TextChatService:CanUserChatAsync()](https://create.roblox.com/docs/reference/engine/classes/TextChatService#CanUsersChatAsync).

## Changes

TextChatService:CanUserChatAsync() can be used within local scripts, but only with the userId of the local player. Attempting to use this method with another player's userId (in the server or not) will result in this error:
![image](https://github.com/user-attachments/assets/357cc7f1-9780-474e-a1e6-6cdcdbaafe9c)

Credit to [@xyrafrost](https://devforum.roblox.com/u/xyrafrost) for the [original bug report](https://devforum.roblox.com/t/feedback-on-textchatservice/3449366) regarding this inconsistency.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
