### PR TITLE
Remove Tolerance from OverlayParams in WorldRoot

### DIFF
--- a/content/en-us/reference/engine/classes/WorldRoot.yaml
+++ b/content/en-us/reference/engine/classes/WorldRoot.yaml
@@ -522,7 +522,7 @@ methods:
           The size of the given box volume to be queried.
       - name: overlapParams
         type: OverlapParams
-        default: OverlapParams{MaxParts=0, Tolerance=0, BruteForceAllSlow=false, RespectCanCollide=false, CollisionGroup=Default, FilterDescendantsInstances={}}
+        default: OverlapParams{MaxParts=0, BruteForceAllSlow=false, RespectCanCollide=false, CollisionGroup=Default, FilterDescendantsInstances={}}
         summary: |
           Contains reusable portions of the spatial query parameters.
     returns:
@@ -572,7 +572,7 @@ methods:
           The radius of the given sphere volume to be queried.
       - name: overlapParams
         type: OverlapParams
-        default: OverlapParams{MaxParts=0, Tolerance=0, BruteForceAllSlow=false, RespectCanCollide=false, CollisionGroup=Default, FilterDescendantsInstances={}}
+        default: OverlapParams{MaxParts=0, BruteForceAllSlow=false, RespectCanCollide=false, CollisionGroup=Default, FilterDescendantsInstances={}}
         summary: |
           Contains reusable portions of the spatial query parameters.
     returns:
@@ -621,7 +621,7 @@ methods:
           The part whose volume is to be checked against other parts.
       - name: overlapParams
         type: OverlapParams
-        default: OverlapParams{MaxParts=0, Tolerance=0, BruteForceAllSlow=false, RespectCanCollide=false, CollisionGroup=Default, FilterDescendantsInstances={}}
+        default: OverlapParams{MaxParts=0, BruteForceAllSlow=false, RespectCanCollide=false, CollisionGroup=Default, FilterDescendantsInstances={}}
         summary: |
           Contains reusable portions of the spatial query parameters.
     returns:


### PR DESCRIPTION
## Changes

Remove Tolerance from OverlayParams in WorldRoot

![image](https://github.com/user-attachments/assets/00d0dd9e-7d0a-4855-a695-4eb6f12cd2bb)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
