### PR TITLE
Clarify HapticEffect is not out on HapticService deprecation msg

### DIFF
--- a/content/en-us/reference/engine/classes/HapticService.yaml
+++ b/content/en-us/reference/engine/classes/HapticService.yaml
@@ -24,7 +24,9 @@ tags:
   - Service
   - NotReplicated
 deprecation_message: |
-  This service will be superseded by `Class.HapticEffect|HapticEffect`, a newer instance that will support multiple haptic effect types, looped effects, and customizable haptics.
+  This service will be superseded by `Class.HapticEffect|HapticEffect`, a newer
+  instance that will support multiple haptic effect types, looped effects, and
+  customizable haptics.
 properties: []
 methods:
   - name: HapticService:GetMotor
@@ -55,7 +57,7 @@ methods:
           and `Enum.VibrationMotor` or `nil` if
           `Class.HapticService:SetMotor()|SetMotor()` has not been called prior.
     tags: []
-    deprecation_message: ""
+    deprecation_message: ''
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -87,7 +89,7 @@ methods:
           Boolean of `true` if the specified motor is available to be used with
           the specified `Enum.UserInputType`, `false` if not.
     tags: []
-    deprecation_message: ""
+    deprecation_message: ''
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -113,7 +115,7 @@ methods:
           Boolean of `true` if the specified `Enum.UserInputType` supports
           haptic feedback.
     tags: []
-    deprecation_message: ""
+    deprecation_message: ''
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -148,9 +150,9 @@ methods:
           the tuple, which should be a number.
     returns:
       - type: void
-        summary: ""
+        summary: ''
     tags: []
-    deprecation_message: ""
+    deprecation_message: ''
     security: None
     thread_safety: Unsafe
     capabilities: []

--- a/content/en-us/reference/engine/classes/HapticService.yaml
+++ b/content/en-us/reference/engine/classes/HapticService.yaml
@@ -23,10 +23,7 @@ tags:
   - NotCreatable
   - Service
   - NotReplicated
-deprecation_message: |
-  This service has been superseded by `Class.HapticEffect`, a newer instance
-  that supports multiple haptic effect types, looped effects, and customizable
-  haptics.
+deprecation_message: ''
 properties: []
 methods:
   - name: HapticService:GetMotor

--- a/content/en-us/reference/engine/classes/HapticService.yaml
+++ b/content/en-us/reference/engine/classes/HapticService.yaml
@@ -23,7 +23,8 @@ tags:
   - NotCreatable
   - Service
   - NotReplicated
-deprecation_message: ''
+deprecation_message: |
+  This service will be superseded by `Class.HapticEffect|HapticEffect`, a newer instance that will support multiple haptic effect types, looped effects, and customizable haptics.
 properties: []
 methods:
   - name: HapticService:GetMotor
@@ -54,7 +55,7 @@ methods:
           and `Enum.VibrationMotor` or `nil` if
           `Class.HapticService:SetMotor()|SetMotor()` has not been called prior.
     tags: []
-    deprecation_message: ''
+    deprecation_message: ""
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -86,7 +87,7 @@ methods:
           Boolean of `true` if the specified motor is available to be used with
           the specified `Enum.UserInputType`, `false` if not.
     tags: []
-    deprecation_message: ''
+    deprecation_message: ""
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -112,7 +113,7 @@ methods:
           Boolean of `true` if the specified `Enum.UserInputType` supports
           haptic feedback.
     tags: []
-    deprecation_message: ''
+    deprecation_message: ""
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -147,9 +148,9 @@ methods:
           the tuple, which should be a number.
     returns:
       - type: void
-        summary: ''
+        summary: ""
     tags: []
-    deprecation_message: ''
+    deprecation_message: ""
     security: None
     thread_safety: Unsafe
     capabilities: []


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
Change deprecation notice in HapticService to clarify that HapticEffect is not yet available, and set an alias so `Class.` is not visible but it will still link to `HapticEffect` when it is added.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
Report: https://devforum.roblox.com/t/feedback-on-hapticservice/3466028/2
## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
