### PR TITLE
Remove outdated bullet point

### DIFF
--- a/content/en-us/studio/microprofiler/task-scheduler.md
+++ b/content/en-us/studio/microprofiler/task-scheduler.md
@@ -40,9 +40,6 @@ To build performant games with efficiency in mind, note the following:
 - **Don't connect/bind functions to the render step unless absolutely necessary.**
   Only tasks that must be done after input but before rendering should be done in such a way, like camera movement. For strict control over order, use `Class.RunService:BindToRenderStep()|BindToRenderStep()` instead of `Class.RunService.PreRender|PreRender`.
 
-- **Minimize the amount of waiting scripts.**
-  Avoid using `while task.wait() do end` or `while true do task.wait() end` constructs, since these aren't guaranteed to run exactly every frame or gameplay step. Instead, use an event like `Class.RunService.Heartbeat|Heartbeat`. Similarly, avoid using `Library.task.spawn()` or `Library.task.delay()` as they use the same internal mechanics as `Library.task.wait()`. Uses of `Global.RobloxGlobals.spawn()` are generally better served with `Library.coroutine.wrap()` and `Library.coroutine.resume()` of the `Library.coroutine` library.
-
 - **Manage physical states carefully.**
   `Class.RunService.PreSimulation|PreSimulation` happens **before** physics, while `Class.RunService.PostSimulation|PostSimulation` happens **after** physics. Therefore, gameplay logic that affects the physics state should be done in `Class.RunService.PreSimulation|PreSimulation`, such as setting the `Class.BasePart.Velocity|Velocity` of parts. In contrast, gameplay logic that relies on or reacts to the physics state should be handled in `Class.RunService.PostSimulation|PostSimulation`, such as reading the `Class.BasePart.Position|Position` of parts to detect when they enter defined zones.
 


### PR DESCRIPTION
## Changes

Removes an outdated bullet point regarding the use of `task.wait/task.spawn/task.delay`. It seems this is a holdover from the older global functions `wait/spawn/delay`, and that someone had simply added the `task` prefix to those older functions in this paragraph (you can see this was forgotten on the last reference to `spawn()`).

To the best of my understanding, the newer task library has no throttling issues like the older global functions, and thus the docs should not be recommending against their usage.

Relevant links:
- https://devforum.roblox.com/t/task-library-now-available/1387845
- https://create.roblox.com/docs/reference/engine/libraries/task

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
