### PR TITLE
Clarify how AnimationTrack:Stop() with a fadeTime of 0 affects Motor6Ds

### DIFF
--- a/content/en-us/reference/engine/classes/AnimationTrack.yaml
+++ b/content/en-us/reference/engine/classes/AnimationTrack.yaml
@@ -617,8 +617,11 @@ methods:
       of the initial weight of the animation.
 
       It is not recommended to use a fadeTime of 0 seconds to try to override
-      this effect and end the animation immediately as presently, this causes
-      the `Class.AnimationTrack` poses to freeze.
+      this effect and end the animation immediately for `Class.Motor6D|Motor6Ds`
+      that have their `Class.Motor.MaxVelocity` set to zero, as this causes
+      the joints to freeze in place. If it must end immediately, ensure the
+      `Class.Motor.MaxVelocity` of `Class.Motor6D|Motor6Ds` in your rig are
+      high enough for them to snap properly.
     code_samples:
       - AnimationTrack-Stop
     parameters:


### PR DESCRIPTION
## Changes

When calling `AnimationTrack:Stop()` with a fadeTime of 0, poses do not freeze in place by intention. It happens due to the `MaxVelocity` of Motor6Ds in the rig being zero, meaning they cannot return back to their desired angle (since they inherit Motors).

I believe the misconception in the passage I edited was due to the default StarterCharacter rigs having the MaxVelocity of all joints set to zero rather than something like TAU (which should be optimal, given MaxVelocity is in radians). I've also tested this below:

Rig with MaxVelocity set to 0 for all Motor6Ds, calling `AnimationTrack:Stop(0)`:
![RobloxStudioBeta_aAWKhiW44t](https://github.com/user-attachments/assets/5ba4f82d-5300-483f-94c5-e952be078998)

Rig with MaxVelocity set to TAU for all Motor6Ds, calling `AnimationTrack:Stop(0)`:
![RobloxStudioBeta_erHkiFJMix](https://github.com/user-attachments/assets/80ca2302-5156-4688-b1ba-f523c31032c8)

Bones are not affected by this issue since they do not inherit Motor.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
