### PR TITLE
Update Workspace.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/Workspace.yaml
+++ b/content/en-us/reference/engine/classes/Workspace.yaml
@@ -30,8 +30,8 @@ description: |
 
   `Class.Workspace` can be accessed several ways, all of which are valid.
 
-  - `game:GetService("Workspace")` (recommended)
   - `workspace`
+  - `game:GetService("Workspace")`
   - `game.Workspace`
 
   ##### Notes


### PR DESCRIPTION
game:GetService("Workspace") is unnecessary, workspace is global https://create.roblox.com/docs/reference/engine/globals/RobloxGlobals#workspace

I see no purpose of recommending that, using GetService for workspace is sacrilegious

## Changes

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
