### PR TITLE
Fix typo "Spacial" to "Spatial" in tag-table.md

### DIFF
--- a/content/en-us/studio/microprofiler/tag-table.md
+++ b/content/en-us/studio/microprofiler/tag-table.md
@@ -344,7 +344,7 @@ When threads aren't actively performing tasks, they enter a sleep state, with ta
     <td>Reduce the amount and complexity of physically simulated bodies.</td>
   </tr>
   <tr>
-    <td>Simulation/physicsSteppedTotal/physicsStepped/SpacialFilter/filterStep</td>
+    <td>Simulation/physicsSteppedTotal/physicsStepped/SpatialFilter/filterStep</td>
     <td>Updates simulation islands, arranging parts according to network ownership, local simulation. Islands are non-interacting groups of parts which can be simulated independently.</td>
     <td>Avoid setting network ownership frequently. Keep groups of parts far enough away from each other so they can be simulated separately.</td>
   </tr>


### PR DESCRIPTION
## Changes

The tag as shown in MicroProfiler is "frameStep/SpatialFilter" not "frameStep/SpacialFilter".

I fixed the spelling.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
