### PR TITLE
Update RunService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/RunService.yaml
+++ b/content/en-us/reference/engine/classes/RunService.yaml
@@ -671,7 +671,7 @@ events:
         summary: |
           The time (in seconds) that has elapsed since the previous frame.
     tags: []
-    deprecation_message: ''This event has been superceded by <code>Class.RunService.PreRender|PreRender</code>.''
+    deprecation_message: 'This event has been superceded by <code>Class.RunService.PreRender|PreRender</code>.'
     security: None
     thread_safety: Unsafe
     capabilities: []

--- a/content/en-us/reference/engine/classes/RunService.yaml
+++ b/content/en-us/reference/engine/classes/RunService.yaml
@@ -566,13 +566,13 @@ events:
     summary: |
       Fires every frame, after the physics simulation has completed.
     description: |
-      The `PostSimulation` event (replacement for
-      `Class.RunService.Heartbeat|Heartbeat`) fires every frame, after the physics simulation
+      The `PostSimulation` event fires every frame, after the physics simulation
       has completed. The `deltaTimeSim` argument indicates the time that has
       elapsed since the previous frame.
 
       This event is useful for making final adjustments to the outcome of the
-      simulation.
+      simulation. Following this phase, the engine triggers the
+      `Class.RunService.Heartbeat|Heartbeat` event.
     code_samples:
     parameters:
       - name: deltaTimeSim
@@ -671,7 +671,7 @@ events:
         summary: |
           The time (in seconds) that has elapsed since the previous frame.
     tags: []
-    deprecation_message: 'This event has been superceded by <code>Class.RunService.PreRender|PreRender</code>.'
+    deprecation_message: ''
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -679,24 +679,7 @@ events:
   - name: RunService.RenderStepped
     summary: |
       Fires every frame, prior to the frame being rendered.
-    description: |
-      The `RenderStepped` event fires every frame, prior to the
-      frame being rendered. The `deltaTime` argument indicates the time that has
-      elapsed since the previous frame.
-
-      This event allows you to run code and update the world before it's drawn
-      on a player's screen. This is useful for last‑minute adjustments such as
-      changing object positions, updating animations, or preparing visual
-      effects, but it should be used sparingly as the engine cannot start to
-      render the frame until code running in this event has finished executing.
-
-      As `RenderStepped` is client-side, it can only be used in a
-      `Class.LocalScript`, in a `Class.ModuleScript` required by a
-      `Class.LocalScript`, or in a `Class.Script` with
-      `Class.BaseScript.RunContext|RunContext` set to `Enum.RunContext.Client`.
-
-      Following the `RenderStepped` phase, the simulation phase begins with the
-      `Class.RunService.Stepped|Stepped` event.
+    description: ''
     code_samples: []
     parameters:
       - name: deltaTime
@@ -705,7 +688,8 @@ events:
         summary: |
           The time (in seconds) that has elapsed since the previous frame.
     tags: []
-    deprecation_message: 'This event has been superceded by <code>Class.RunService.PreSimulation|PreSimulation</code>.'
+    deprecation_message: |
+      This event has been superseded by `Class.RunService.PreRender|PreRender` which should be used for new work.
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -713,16 +697,7 @@ events:
   - name: RunService.Stepped
     summary: |
       Fires every frame, prior to the physics simulation.
-    description: |
-      The `Stepped` event fires every frame, prior
-      to the physics simulation. The `deltaTime` argument indicates the time
-      that has elapsed since the previous frame.
-
-      This event is useful for adjusting properties like velocity or forces just
-      before they're applied as part of the simulation. The simulation then
-      runs, potentially multiple times, as the physics solver runs at a higher
-      frequency than other engine systems. Once this is complete, the
-      `Class.RunService.Heartbeat|Heartbeat` event is fired.
+    description: ''
     code_samples: []
     parameters:
       - name: time
@@ -737,7 +712,8 @@ events:
         summary: |
           The time (in seconds) that has elapsed since the previous frame.
     tags: []
-    deprecation_message: ''
+    deprecation_message: |
+      This event has been superseded by `Class.RunService.PreSimulation|PreSimulation` which should be used for new work.
     security: None
     thread_safety: Unsafe
     capabilities: []

--- a/content/en-us/reference/engine/classes/RunService.yaml
+++ b/content/en-us/reference/engine/classes/RunService.yaml
@@ -525,7 +525,7 @@ methods:
       - type: void
         summary: ''
     tags: []
-    deprecation_message: ''
+    deprecation_message: 'This event has been superceded by <code>Class.RunService.PostSimulation|PostSimulation</code>.'
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -566,13 +566,13 @@ events:
     summary: |
       Fires every frame, after the physics simulation has completed.
     description: |
-      The `PostSimulation` event fires every frame, after the physics simulation
+      The `PostSimulation` event (replacement for
+      `Class.RunService.Heartbeat|Heartbeat`) fires every frame, after the physics simulation
       has completed. The `deltaTimeSim` argument indicates the time that has
       elapsed since the previous frame.
 
       This event is useful for making final adjustments to the outcome of the
-      simulation. Following this phase, the engine triggers the
-      `Class.RunService.Heartbeat|Heartbeat` event.
+      simulation.
     code_samples:
     parameters:
       - name: deltaTimeSim
@@ -618,7 +618,7 @@ events:
     summary: |
       Fires every frame, prior to the frame being rendered.
     description: |
-      The `PreRender` event (equivalent to
+      The `PreRender` event (replacement for
       `Class.RunService.RenderStepped|RenderStepped`) fires every frame, prior
       to the frame being rendered. The `deltaTimeRender` argument indicates the
       time that has elapsed since the previous frame.
@@ -653,7 +653,7 @@ events:
     summary: |
       Fires every frame, prior to the physics simulation.
     description: |
-      The `PreSimulation` event (equivalent to
+      The `PreSimulation` event (replacement for
       `Class.RunService.Stepped|Stepped`) fires every frame, prior to the
       physics simulation. The `deltaTimeSim` argument indicates the time that
       has elapsed since the previous frame.
@@ -671,7 +671,7 @@ events:
         summary: |
           The time (in seconds) that has elapsed since the previous frame.
     tags: []
-    deprecation_message: ''
+    deprecation_message: ''This event has been superceded by <code>Class.RunService.PreRender|PreRender</code>.''
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -680,8 +680,7 @@ events:
     summary: |
       Fires every frame, prior to the frame being rendered.
     description: |
-      The `RenderStepped` event (equivalent to
-      `Class.RunService.PreRender|PreRender`) fires every frame, prior to the
+      The `RenderStepped` event fires every frame, prior to the
       frame being rendered. The `deltaTime` argument indicates the time that has
       elapsed since the previous frame.
 
@@ -697,7 +696,7 @@ events:
       `Class.BaseScript.RunContext|RunContext` set to `Enum.RunContext.Client`.
 
       Following the `RenderStepped` phase, the simulation phase begins with the
-      `Class.RunService.PreAnimation|PreAnimation` event.
+      `Class.RunService.Stepped|Stepped` event.
     code_samples: []
     parameters:
       - name: deltaTime
@@ -706,7 +705,7 @@ events:
         summary: |
           The time (in seconds) that has elapsed since the previous frame.
     tags: []
-    deprecation_message: ''
+    deprecation_message: 'This event has been superceded by <code>Class.RunService.PreSimulation|PreSimulation</code>.'
     security: None
     thread_safety: Unsafe
     capabilities: []
@@ -715,8 +714,7 @@ events:
     summary: |
       Fires every frame, prior to the physics simulation.
     description: |
-      The `Stepped` event (equivalent to
-      `Class.RunService.PreSimulation|PreSimulation`) fires every frame, prior
+      The `Stepped` event fires every frame, prior
       to the physics simulation. The `deltaTime` argument indicates the time
       that has elapsed since the previous frame.
 
@@ -724,7 +722,7 @@ events:
       before they're applied as part of the simulation. The simulation then
       runs, potentially multiple times, as the physics solver runs at a higher
       frequency than other engine systems. Once this is complete, the
-      `Class.RunService.PostSimulation|PostSimulation` event is fired.
+      `Class.RunService.Heartbeat|Heartbeat` event is fired.
     code_samples: []
     parameters:
       - name: time

--- a/content/en-us/reference/engine/classes/RunService.yaml
+++ b/content/en-us/reference/engine/classes/RunService.yaml
@@ -525,7 +525,7 @@ methods:
       - type: void
         summary: ''
     tags: []
-    deprecation_message: 'This event has been superceded by <code>Class.RunService.PostSimulation|PostSimulation</code>.'
+    deprecation_message: ''
     security: None
     thread_safety: Unsafe
     capabilities: []


### PR DESCRIPTION
Added deprecation messages for Heartbeat, RenderStepped, and Stepped. Changed statements in PreRender, PreSimulation, and PostSimulation saying that they are equivalent to RenderStepped, Stepped, and Heartbeat to saying that they are their respective replacements.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
