### PR TITLE
Unessesary word in bubble-chat.md

### DIFF
--- a/content/en-us/chat/bubble-chat.md
+++ b/content/en-us/chat/bubble-chat.md
@@ -15,7 +15,7 @@ To enable bubble chat in your experience:
 
    <img src="../assets/players/in-experience-text-chat/TextChatService-BubbleChatConfiguration.png" width="320" />
 
-2. In the [Properties](../studio/properties.md) window, check the `Class.BubbleChatConfiguration.Enabled|Enabled` checkbox.
+2. In the [Properties](../studio/properties.md) window, check the `Class.BubbleChatConfiguration.Enabled` checkbox.
 
    <img src="../assets/players/in-experience-text-chat/TextChatService-BubbleChatConfiguration-Enabled.png" width="320" />
 


### PR DESCRIPTION
## Changes

In content/en-us/chat/bubble-chat.md, line 18 it should be 

`2. In the [Properties](../studio/properties.md) window, check the Class.BubbleChatConfiguration.Enabled checkbox.`

and not 

`2. In the [Properties](../studio/properties.md) window, check the Class.BubbleChatConfiguration.Enabled|Enabled checkbox.`

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
