### PR TITLE
Add UUID Version & Variant to GenerateGUID description

### DIFF
--- a/content/en-us/reference/engine/classes/HttpService.yaml
+++ b/content/en-us/reference/engine/classes/HttpService.yaml
@@ -111,12 +111,14 @@ methods:
     summary: |
       Generates a UUID/GUID random string, optionally with curly braces.
     description: |
-      This method randomly creates a [universally unique identifier
+      This method randomly creates a universally unique identifier
       [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
       string. The sixteen octets of a UUID are represented as 32 hexadecimal
       (base 16) digits, displayed in 5 groups separated by hyphens in the form
       `8-4-4-4-12` for a total of 36 characters, for example
-      `123e4567-e89b-12d3-a456-426655440000`.
+      `123e4567-e89b-12d3-a456-426655440000`. The UUID specification used is
+      [Version 4 (Random Data)](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random))
+      Variant 1 (DCE 1.1, ISO/IEC 11578:1996).
 
       The `wrapInCurlyBraces` argument determines whether the returned string is
       wrapped in curly braces (`{}`). For instance:


### PR DESCRIPTION
## Changes

* Added a sentence detailing the **Version (4)** and **Variant (1)** of the UUID algorithm used.
  * This was determined by generating a GUID (for example `564c5179-c21c-48e1-b5bb-8bd09f00d3f6`) and entering it into a [public UUID decoder](https://www.uuidtools.com/decode).
  * I don't believe adding this sentence is of any compromise to security since anyone could publicly do this.
  * This added sentence of information is helpful to note, as this version does not have certain features that other UUID versions have such as encoded timestamps, MAC addresses, or being sortable by time ([UUIDv7](https://uuid7.com/), [ULID](https://github.com/ulid/spec)).
  * More info at [Wikipedia](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) or https://www.uuidtools.com/uuid-versions-explained
* Fixed a typo: Extraneous "[" was removed

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
