### PR TITLE
Added code snippet for deriving TextChatMessageProperties

### DIFF
--- a/content/en-us/reference/engine/classes/TextChatMessageProperties.yaml
+++ b/content/en-us/reference/engine/classes/TextChatMessageProperties.yaml
@@ -14,20 +14,19 @@ description: |
 
   ```lua title='LocalScript - Retrieving and Using TextChatMessageProperties'
   local TextChatService = game:GetService("TextChatService")
+  
   TextChatService.OnIncomingMessage = function(message: TextChatMessage)
-    -- deriving TextChatMessageProperties
-    local properties = TextChatService.ChatWindowConfiguration:DeriveNewMessageProperties()
-    
-    -- changing color of messsage
-    properties.TextColor3 = Color3.fromRGB(255, 121, 121)
-    
-    -- setting message's chatwindowmessageproperties
-    message.ChatWindowMessageProperties = properties
-
-    return properties	
+  	-- Derive chat message properties
+  	local properties = TextChatService.ChatWindowConfiguration:DeriveNewMessageProperties()
+  
+  	-- Change color of message
+  	properties.TextColor3 = Color3.fromRGB(255, 121, 121)
+  
+  	-- Set chat window message properties
+    	message.ChatWindowMessageProperties = properties
+  
+  	return properties	
   end
-  ```
-
 code_samples: []
 inherits:
   - Instance

--- a/content/en-us/reference/engine/classes/TextChatMessageProperties.yaml
+++ b/content/en-us/reference/engine/classes/TextChatMessageProperties.yaml
@@ -11,6 +11,23 @@ description: |
   defined in `Class.TextChatService.OnIncomingMessage` or
   `Class.TextChannel.OnIncomingMessage`. This can be used to customize the
   appearance of a message with [rich text](../../../ui/rich-text.md) tags.
+
+  ```lua title='LocalScript - Retrieving and Using TextChatMessageProperties'
+  local TextChatService = game:GetService("TextChatService")
+  TextChatService.OnIncomingMessage = function(message: TextChatMessage)
+    -- deriving TextChatMessageProperties
+    local properties = TextChatService.ChatWindowConfiguration:DeriveNewMessageProperties()
+    
+    -- changing color of messsage
+    properties.TextColor3 = Color3.fromRGB(255, 121, 121)
+    
+    -- setting message's chatwindowmessageproperties
+    message.ChatWindowMessageProperties = properties
+
+    return properties	
+  end
+  ```
+
 code_samples: []
 inherits:
   - Instance


### PR DESCRIPTION
## Changes

I was trying to figure out how to derive TextChatMessageProperites, and I couldn't find it anywhere. This PR aims to add a code snippet to the TextChatMessageProperties page ( https://create.roblox.com/docs/reference/engine/classes/TextChatMessageProperties ) that will show how to do so.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
