### PR TITLE
Improve documentation for CreateAssetAsync

### DIFF
--- a/content/en-us/reference/engine/classes/AssetService.yaml
+++ b/content/en-us/reference/engine/classes/AssetService.yaml
@@ -75,10 +75,12 @@ methods:
     writeCapabilities: []
   - name: AssetService:CreateAssetAsync
     summary: |
-      Creates a new asset from the given object.
+      Uploads a new asset to Roblox from the given object.
     description: |
-      Creates a new asset from the given object in Plugin or Open Cloud Luau
-      Execution context.
+      Uploads a new asset to Roblox from the given object.
+
+      This method can only be used in locally loaded plugins and uploads
+      assets without prompting first.
     code_samples:
       - AssetService-CreateAssetAsync
     parameters:
@@ -133,8 +135,10 @@ methods:
     summary: |
       Creates a new version for an existing asset from the given object.
     description: |
-      Creates a new version for an existing asset from the given object in
-      Plugin or Open Cloud Luau Execution context.
+      Uploads a new version for an existing asset from the given object.
+
+      This method can only be used in locally loaded plugins and uploads
+      assets without prompting first.
     code_samples:
       - AssetService-CreateAssetVersionAsync
     parameters:


### PR DESCRIPTION
## Changes

The asset creation currently is only usable by plugins loaded in the LocalPlugin folder, this change marks that in the two relevant methods.

(possible TODO: moderation note?)

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
