### PR TITLE
Clarity around the sender/receiver in ShouldDeliverCallback.

### DIFF
--- a/content/en-us/reference/engine/classes/TextChannel.yaml
+++ b/content/en-us/reference/engine/classes/TextChannel.yaml
@@ -293,21 +293,23 @@ callbacks:
       returns anything else (including `nil`), the message won't be delivered to
       that client, although the sender will see the message regardless.
 
-      The sender can be referenced by `Class.TextChatMessage.TextSource`. The 
-      receiver is the `textSource` argument. Note that the sender and receiver
-      can be the same, as the callback iterates through all possible receivers.
-      In Roblox Studio, you will be the only sender and recipient of a message
-      while in Play Solo mode.
+      The sender can be referenced by `Class.TextChatMessage.TextSource`,
+      while the receiver is the `textSource` argument. Note that the sender
+      and receiver can be the same, as the callback iterates through all possible
+      receivers. In Roblox Studio, you will be the only sender and recipient of a
+      message while in solo **Play** mode.
     code_samples: []
     parameters:
       - name: message
         type: TextChatMessage
         default:
-        summary: 'The message being sent, which also contains the sender of the message.'
+        summary: |
+          The message being sent, which also contains the sender of the message.
       - name: textSource
         type: TextSource
         default:
-        summary: 'The `Class.TextSource` of the user who will be receiving the message.'
+        summary: |
+          The `Class.TextSource` of the user who will be receiving the message.
     returns:
       - type: Tuple
         summary: ''

--- a/content/en-us/reference/engine/classes/TextChannel.yaml
+++ b/content/en-us/reference/engine/classes/TextChannel.yaml
@@ -293,17 +293,21 @@ callbacks:
       returns anything else (including `nil`), the message won't be delivered to
       that client, although the sender will see the message regardless.
 
-      The sender can be referenced by `Class.TextChatMessage.TextSource`.
+      The sender can be referenced by `Class.TextChatMessage.TextSource`. The 
+      receiver is the `textSource` argument. Note that the sender and receiver
+      can be the same, as the callback iterates through all possible receivers.
+      In Roblox Studio, you will be the only sender and recipient of a message
+      while in Play Solo mode.
     code_samples: []
     parameters:
       - name: message
         type: TextChatMessage
         default:
-        summary: ''
+        summary: 'The message being sent, which also contains the sender of the message.'
       - name: textSource
         type: TextSource
         default:
-        summary: ''
+        summary: 'The `Class.TextSource` of the user who will be receiving the message.'
     returns:
       - type: Tuple
         summary: ''


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

Elaborated on the sender/receiver structure of `TextChannel.ShouldDeliverCallback`. My co-worker got confused while he was working on a problem with us and thought the callback only gave you information about who sent the message, since in Play Solo you would be the only sender and recipient of the message. After confirming how I suspected it actually worked, I went in and made this documentation change so others hopefully don't have similar confusion in the future.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
