### PR TITLE
Replace their with there and mention that Lighting.Technology cannot be accessed from Roblox Studio

### DIFF
--- a/content/en-us/reference/engine/classes/DataModelMesh.yaml
+++ b/content/en-us/reference/engine/classes/DataModelMesh.yaml
@@ -96,7 +96,7 @@ properties:
         cylinder, using the lowest value.
       - `Class.SpecialMesh` objects with `Class.SpecialMesh.FileType` set to
         'Head' currently scale in a non standard manner. Developers should not
-        rely on this as there are plans to change this behavior
+        rely on this as there are plans to change this behavior.
       - `Class.SpecialMesh` objects with `Class.SpecialMesh.FileType` set to
         'Torso' scale in a non standard manner. Developers should not rely on
         this as there are plans to deprecate this mesh type.

--- a/content/en-us/reference/engine/classes/DataModelMesh.yaml
+++ b/content/en-us/reference/engine/classes/DataModelMesh.yaml
@@ -96,10 +96,10 @@ properties:
         cylinder, using the lowest value.
       - `Class.SpecialMesh` objects with `Class.SpecialMesh.FileType` set to
         'Head' currently scale in a non standard manner. Developers should not
-        rely on this as their are plans to change this behavior
+        rely on this as there are plans to change this behavior
       - `Class.SpecialMesh` objects with `Class.SpecialMesh.FileType` set to
         'Torso' scale in a non standard manner. Developers should not rely on
-        this as their are plans to deprecate this mesh type.
+        this as there are plans to deprecate this mesh type.
 
       #### Mesh scale demonstration
 

--- a/content/en-us/reference/engine/classes/Lighting.yaml
+++ b/content/en-us/reference/engine/classes/Lighting.yaml
@@ -564,7 +564,7 @@ properties:
       .
     description: |
       Determines the lighting system for rendering the 3D world. This property
-      is non‑scriptable and is no longer accessible in Roblox Studio. Use `Class.Lighting.LightingStyle|LightingStyle` instead. See `Enum.Technology` for
+      is non‑scriptable and only modifiable in Studio. See `Enum.Technology` for
       available options and
       [Lighting Technology](../../../environment/lighting.md#technology) for
       detailed descriptions and visual effects of each option.

--- a/content/en-us/reference/engine/classes/Lighting.yaml
+++ b/content/en-us/reference/engine/classes/Lighting.yaml
@@ -564,7 +564,7 @@ properties:
       .
     description: |
       Determines the lighting system for rendering the 3D world. This property
-      is non‑scriptable and only modifiable in Studio. See `Enum.Technology` for
+      is non‑scriptable and is no longer accessible in Roblox Studio. See `Enum.Technology` for
       available options and
       [Lighting Technology](../../../environment/lighting.md#technology) for
       detailed descriptions and visual effects of each option.

--- a/content/en-us/reference/engine/classes/Lighting.yaml
+++ b/content/en-us/reference/engine/classes/Lighting.yaml
@@ -413,7 +413,7 @@ properties:
     deprecation_message: ''
     security:
       read: None
-      write: None
+      write: StudioSecurity
     thread_safety: ReadSafe
     category: Appearance
     serialization:
@@ -564,7 +564,7 @@ properties:
       .
     description: |
       Determines the lighting system for rendering the 3D world. This property
-      is non‑scriptable and is no longer accessible in Roblox Studio. See `Enum.Technology` for
+      is non‑scriptable and is no longer accessible in Roblox Studio. Use `Class.Lighting.LightingStyle|LightingStyle` instead. See `Enum.Technology` for
       available options and
       [Lighting Technology](../../../environment/lighting.md#technology) for
       detailed descriptions and visual effects of each option.

--- a/content/en-us/reference/engine/classes/Lighting.yaml
+++ b/content/en-us/reference/engine/classes/Lighting.yaml
@@ -413,7 +413,7 @@ properties:
     deprecation_message: ''
     security:
       read: None
-      write: StudioSecurity
+      write: None
     thread_safety: ReadSafe
     category: Appearance
     serialization:

--- a/content/en-us/reference/engine/classes/VideoService.yaml
+++ b/content/en-us/reference/engine/classes/VideoService.yaml
@@ -2,7 +2,7 @@ name: VideoService
 type: class
 category:
 memory_category: Instances
-summary: ''
+summary: 'An internal service that offers no functionality to developers.'
 description: ''
 code_samples: []
 inherits:

--- a/content/en-us/reference/engine/classes/VideoService.yaml
+++ b/content/en-us/reference/engine/classes/VideoService.yaml
@@ -2,7 +2,8 @@ name: VideoService
 type: class
 category:
 memory_category: Instances
-summary: 'An internal service that offers no functionality to developers.'
+summary: |
+  An internal service that offers no functionality to developers.
 description: ''
 code_samples: []
 inherits:


### PR DESCRIPTION
## Changes

Replaced "their are plans in the future" with "there are plans in the future" in the How to use Scale section. Also I fixed a misinformation stating that Lighting.Technology can be changed from Roblox Studio - it can't be even read from studio.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
