### PR TITLE
Update AssetDelivery API param name to improve clarity

### DIFF
--- a/content/en-us/cloud/legacy.md
+++ b/content/en-us/cloud/legacy.md
@@ -18,7 +18,7 @@ This section contains documentation for Roblox's legacy REST APIs.
 | **API**                                 | **Path**                                                                  | **Scope**                |
 | :-------------------------------------- | :------------------------------------------------------------------------ | :----------------------- |
 | GetAssetById                            | `GET /v1/assetId/{assetId}`                                               | `legacy-asset:manage`    |
-| GetAssetVersionById                     | `GET /v1/assetId/{assetId}/version/{version}`                             | `legacy-asset:manage`    |
+| GetAssetVersionById                     | `GET /v1/assetId/{assetId}/version/{versionNumber}`                       | `legacy-asset:manage`    |
 
 ## Badges API
 


### PR DESCRIPTION
## Changes

Updating from `{version}` to `{versionNumber}` to match [documentation on other pages](https://create.roblox.com/docs/cloud/features/assets#/default/Assets_GetAssetVersion) and so it is not confused with `assetVersionId`.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
