### PR TITLE
Fix intro-to-module-scripts.md having a mixup

### DIFF
--- a/content/en-us/tutorials/fundamentals/coding-6/intro-to-module-scripts.md
+++ b/content/en-us/tutorials/fundamentals/coding-6/intro-to-module-scripts.md
@@ -23,7 +23,7 @@ Module scripts are actually their own separate object compared to script objects
 
 ModuleScripts are commonly placed in **ServerScriptService** when used by server-side scripts and **ReplicatedStorage** when used by client-side local scripts (such as GUI interactions).
 
-1. Create a **ModuleScript** in **ServerStorage**.
+1. Create a **ModuleScript** in **ServerScriptService**.
 
 <img src="../../../assets/education/coding-6/intro-to-module-scripts/create-module-script.png" width="50%" />
 


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
to be specific, it says to create a ModuleScript in ServerStorage, but it is previously stated that they are commonly placed in ServerScriptService, so this fixes it
<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
No links are needed, as the file and image right below the line I changed both state that it should be in ServerScriptService
## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.