### PR TITLE
Fixed Typo

### DIFF
--- a/content/en-us/resources/plant-reference-project.md
+++ b/content/en-us/resources/plant-reference-project.md
@@ -366,7 +366,7 @@ happens alongside the instance itself.
 
 This is particularly useful for instances created at runtime, as attributes set
 on a new instance before it is parented to the data model will replicate
-atomically with the instance itself. This circumvents any need to write code to
+automatically with the instance itself. This circumvents any need to write code to
 "wait" for extra data to be replicated via a `Class.RemoteEvent` or
 `Class.StringValue`.
 


### PR DESCRIPTION
Fixed a typo in the [Plant reference project](https://create.roblox.com/docs/resources/plant-reference-project) page under the [Replication via attributes](https://create.roblox.com/docs/resources/plant-reference-project#replication-via-attributes) section of Client-server communication where "automatically" was misspelled "atomically".

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
