### PR TITLE
Update AnimationClipProvider.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/AnimationClipProvider.yaml
+++ b/content/en-us/reference/engine/classes/AnimationClipProvider.yaml
@@ -131,7 +131,7 @@ methods:
 
       This function performs the same function to
       `Class.AnimationClipProvider:RegisterActiveAnimationClip()|RegisterActiveAnimationClip`
-      yet generates an _active://_ URL instead of a hash.
+      yet generates a hash instead of an `active://` URL.
 
       The ID generated can be used for the `Class.Animation.AnimationId`
       property to test animations.


### PR DESCRIPTION
Fixes some slight misinfo that is copied from [RegisterActiveAnimationClip](https://create.roblox.com/docs/reference/engine/classes/AnimationClipProvider#RegisterActiveAnimationClip) into [RegisterAnimationClip](https://create.roblox.com/docs/reference/engine/classes/AnimationClipProvider#RegisterAnimationClip) as placeholder. RegisterActiveAnimationClip generates an `active://` URL, while RegisterAnimationClip generates a hash. Both do not generate a `active://` URL.

Documentation issue was brought to my attention [here](https://devforum.roblox.com/t/registeractiveanimationclip-and-registeranimationclip-has-seemingly-identical-descriptions-with-similar-word-choices/3598095) by [@TaylorsRus](https://devforum.roblox.com/u/TaylorsRus).

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
