### PR TITLE
Added Next Gen Studio Preview note to PluginToolbarButton

### DIFF
--- a/content/en-us/reference/engine/classes/PluginToolbarButton.yaml
+++ b/content/en-us/reference/engine/classes/PluginToolbarButton.yaml
@@ -44,6 +44,9 @@ properties:
       occur in the game world (Workspace). For example, a button that opens a
       widget should have this property be true, as showing a widget is visible
       to the user even if the game view isn't visible.
+
+      When the `Class.Plugin` is used with the **Next Gen Studio Preview** beta option enabled, this property
+      will have no effect and will always behave like if it was set to false.
     code_samples:
     type: bool
     tags:

--- a/content/en-us/reference/engine/classes/PluginToolbarButton.yaml
+++ b/content/en-us/reference/engine/classes/PluginToolbarButton.yaml
@@ -44,9 +44,10 @@ properties:
       occur in the game world (Workspace). For example, a button that opens a
       widget should have this property be true, as showing a widget is visible
       to the user even if the game view isn't visible.
-
-      When the `Class.Plugin` is used with the **Next Gen Studio Preview** beta option enabled, this property
-      will have no effect and will always behave like if it was set to false.
+      <Alert severity="warning">
+        When the `Class.Plugin` is used with the **Next Gen Studio Preview** beta option enabled, this property
+        will have no effect and will always behave like if it was set to false.
+      </Alert>
     code_samples:
     type: bool
     tags:


### PR DESCRIPTION
## Changes

When I enabled the Next Gen Studio Preview option in the beta options, all plugin buttons were clickable when the viewport was hidden, so I mentioned this in the docs.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
