### PR TITLE
Update LineJoinMode.yaml

### DIFF
--- a/content/en-us/reference/engine/enums/LineJoinMode.yaml
+++ b/content/en-us/reference/engine/enums/LineJoinMode.yaml
@@ -7,10 +7,21 @@ description: |
   This enum is used by `Class.UIStroke.LineJoinMode` to determine how corners
   are interpreted.
 
-  See also:
+  <figure>
+  <img src="../../../assets/ui/ui-objects/UIStroke-LineJoinMode-Round.png" width="376" />
+  <figcaption><code>LineJoinMode</code> = <code>Enum.LineJoinMode.Round|Round</code></figcaption>
+  </figure>
+  <figure>
+  <img src="../../../assets/ui/ui-objects/UIStroke-LineJoinMode-Bevel.png" width="376" />
+  <figcaption><code>LineJoinMode</code> = <code>Enum.LineJoinMode.Bevel|Bevel</code></figcaption>
+  </figure>
+  <figure>
+  <img src="../../../assets/ui/ui-objects/UIStroke-LineJoinMode-Miter.png" width="376" />
+  <figcaption><code>LineJoinMode</code> = <code>Enum.LineJoinMode.Miter|Miter</code></figcaption>
+  </figure>
 
   For a more detailed walkthrough of the UIStroke object, take a look at the
-  Applying Strokes article.
+  [UIStroke class](Class.UIStroke).
 code_samples:
 tags: []
 deprecation_message: ''

--- a/content/en-us/reference/engine/enums/LineJoinMode.yaml
+++ b/content/en-us/reference/engine/enums/LineJoinMode.yaml
@@ -7,40 +7,32 @@ description: |
   This enum is used by `Class.UIStroke.LineJoinMode` to determine how corners
   are interpreted.
 
-  <figure>
-  <img src="../../../assets/ui/ui-objects/UIStroke-LineJoinMode-Round.png" width="376" />
-  <figcaption><code>LineJoinMode</code> = <code>Enum.LineJoinMode.Round|Round</code></figcaption>
-  </figure>
-  <figure>
-  <img src="../../../assets/ui/ui-objects/UIStroke-LineJoinMode-Bevel.png" width="376" />
-  <figcaption><code>LineJoinMode</code> = <code>Enum.LineJoinMode.Bevel|Bevel</code></figcaption>
-  </figure>
-  <figure>
-  <img src="../../../assets/ui/ui-objects/UIStroke-LineJoinMode-Miter.png" width="376" />
-  <figcaption><code>LineJoinMode</code> = <code>Enum.LineJoinMode.Miter|Miter</code></figcaption>
-  </figure>
-
-  For a more detailed walkthrough of the UIStroke object, take a look at the
-  [UIStroke class](Class.UIStroke).
+  For a more detailed walkthrough of the `Class.UIStroke` object, see [here](../../../ui/appearance-modifiers.md#stroke).
 code_samples:
 tags: []
 deprecation_message: ''
 items:
   - name: Round
     summary: |
-      The corners are rounded (see image above).
+      The corners are rounded.
+
+      <img src="/assets/ui/ui-objects/UIStroke-LineJoinMode-Round.png" width="376" />
     value: 0
     tags: []
     deprecation_message: ''
   - name: Bevel
     summary: |
-      The corners are beveled (see image above).
+      The corners are beveled.
+
+      <img src="/assets/ui/ui-objects/UIStroke-LineJoinMode-Bevel.png" width="376" />
     value: 1
     tags: []
     deprecation_message: ''
   - name: Miter
     summary: |
-      The corners are mitered (see image above).
+      The corners are mitered.
+
+      <img src="/assets/ui/ui-objects/UIStroke-LineJoinMode-Miter.png" width="376" />
     value: 2
     tags: []
     deprecation_message: ''


### PR DESCRIPTION
Added figures from the UIStroke class page, as images are referenced in the table although none exist Changed reference to the "Applying Strokes Article" to reference the UIStroke class page (said article does not exist).

This documentation error was brought to my attention by [@XAXA](https://devforum.roblox.com/u/xaxa) in [this devforum post](https://devforum.roblox.com/t/enumlinejoinmode-documentation-appears-to-be-outdated/3603081).

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
