### PR TITLE
Update Animator.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/Animator.yaml
+++ b/content/en-us/reference/engine/classes/Animator.yaml
@@ -169,6 +169,10 @@ methods:
       `Class.BasePart:SetNetworkOwner()`, this function also loads the animation
       for the server as well.
 
+      Note that the `Class.Animator` must be in the `Class.Workspace` before
+      making a call to `LoadAnimation()` or else it will be unable to retrieve
+      the `Class.AnimationClipProvider` service and error.
+
       You should use this function directly instead of the similarly-named
       `Class.Humanoid:LoadAnimation()` and
       `Class.AnimationController:LoadAnimation()` functions. These are

--- a/content/en-us/reference/engine/classes/Animator.yaml
+++ b/content/en-us/reference/engine/classes/Animator.yaml
@@ -171,7 +171,7 @@ methods:
 
       Note that the `Class.Animator` must be in the `Class.Workspace` before
       making a call to `LoadAnimation()` or else it will be unable to retrieve
-      the `Class.AnimationClipProvider` service and error.
+      the `Class.AnimationClipProvider` service and throw an error.
 
       You should use this function directly instead of the similarly-named
       `Class.Humanoid:LoadAnimation()` and


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
put a note under LoadAnimation documenting possible hard error

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
I ran into this cryptic error "Cannot load the AnimationClipProvider Service." when trying to load an animation. I did some searching and the root cause seems to be calling load animation on an animator that isnt yet parented to the workspace. I have no clue why this is a necessity at all, let alone pressing enough to warrant a hard error. This seems to be a long standing problem that occurs on occasion for humanoids and the regular player model as well, causing some users to have broken animations from the default animation script erroring. See this thread
https://devforum.roblox.com/t/error-cannot-load-the-animationclipprovider-service/1639315/98
## Checks

By submitting your pull request for review, you agree to the following:

- [x ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ x] To the best of my knowledge, all proposed changes are accurate.
