### PR TITLE
Update StarterGui.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/StarterGui.yaml
+++ b/content/en-us/reference/engine/classes/StarterGui.yaml
@@ -340,7 +340,9 @@ methods:
       </table>
 
       ##### ChatMakeSystemMessage
-
+      <Alert severity="warning">
+      Using this method requires the experience's ChatVersion property to be set to LegacyChatService. This chat system is **deprecated** and usage is discouraged. For experiences using the current **TextChatService**, refer to [DisplaySystemMessage](<https://create.roblox.com/docs/reference/engine/classes/TextChannel#DisplaySystemMessage>)
+      </Alert>
       Display a formatted message in the chat.
 
       <table size="small">

--- a/content/en-us/reference/engine/classes/StarterGui.yaml
+++ b/content/en-us/reference/engine/classes/StarterGui.yaml
@@ -340,10 +340,10 @@ methods:
       </table>
 
       ##### ChatMakeSystemMessage
-      <Alert severity="warning">
-      Using this method requires the experience's ChatVersion property to be set to LegacyChatService. This chat system is **deprecated** and usage is discouraged. For experiences using the current **TextChatService**, refer to [DisplaySystemMessage](<https://create.roblox.com/docs/reference/engine/classes/TextChannel#DisplaySystemMessage>)
-      </Alert>
-      Display a formatted message in the chat.
+      Display a formatted message in the chat. Using this method requires the experience's
+      `Class.TextChatService.ChatVersion` to be set to `Enum.ChatVersion|LegacyChatService`, although
+      legacy chat is **deprecated** and usage is discouraged. For experiences using the current
+      `Class.TextChatService`, refer to `Class.TextChannel:DisplaySystemMessage()`.
 
       <table size="small">
       	<thead>


### PR DESCRIPTION
Add warning for MakeChatSystemMessage regarding TextChatService incompatibility; Using MakeChatSystemMessage on modern TextChatService does not work

## Changes

I added a warning to `MakeChatSystemMessage` method about LegacyChatService requirement.
This clarifies that this method only works with the deprecated LegacyChatService and points users to the TextChatService alternative 'DisplaySystemMessage'.

By submitting your pull request for review, you agree to the following:

- [✅] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [✅] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [✅] To the best of my knowledge, all proposed changes are accurate.
