### PR TITLE
Update ProximityPromptService.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/ProximityPromptService.yaml
+++ b/content/en-us/reference/engine/classes/ProximityPromptService.yaml
@@ -211,6 +211,8 @@ events:
       key/button is pressed, or after a specified amount of time holding the
       key/button if the prompt's
       `Class.ProximityPrompt.HoldDuration|HoldDuration` is non-zero.
+
+      The signal will only be handled on the client if it was the same client who triggered this event
     code_samples: []
     parameters:
       - name: prompt


### PR DESCRIPTION
Adding more context to PromptTriggered working differently when used on the client.
If created on the Server, this event will resolve when any player interacts with the prompt.
If created on the Client, only the player who interacts with the prompt will have this event resolved.