### PR TITLE
docs: fix multiple typos

### DIFF
--- a/content/en-us/art/characters/creating/texturing-face.md
+++ b/content/en-us/art/characters/creating/texturing-face.md
@@ -17,7 +17,7 @@ To texture the face:
    1. In Brush Settings, start with the following Brush recommendations:
 
       1. **Radius** to **5px**. You can change this radius as you paint.
-      2. **Strength** to .**30**. Modify this value when applicable.
+      2. **Strength** to **0.300**. Modify this value when applicable.
       3. In Symmetry, enable **X Axis Mirroring**.
 
          <img src="../../../assets/art/avatar/basic-creation/Texture-Symmetry-Tool-Setting.png" />

--- a/content/en-us/education/lesson-plans/roblox-developer-lesson.md
+++ b/content/en-us/education/lesson-plans/roblox-developer-lesson.md
@@ -207,7 +207,7 @@ Teach how to code and create games for the Roblox platform - perfect for educato
     <ul>
     <li><b>Property</b> - Something that controls how an object looks or behaves, like color or if players can walk through it.</li>
     <li><b>Loop</b> - A set of code that repeats until told otherwise.</li>
-    <li><b>Function</b> - A set of instructions can be e re-used in different parts of a script.</li>
+    <li><b>Function</b> - A set of instructions that can be re-used in different parts of a script.</li>
     </ul>
     </td>
    </tr>


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

I have  fixed multiple typos, such as changing `A set of instructions can be e re-used in different parts of a script.` to `A set of instructions that can be re-used in different parts of a script.` and changing `.**30**` to `**0.300**`.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
