### PR TITLE
Patch 2

### DIFF
--- a/content/en-us/reference/engine/classes/CurveAnimation.yaml
+++ b/content/en-us/reference/engine/classes/CurveAnimation.yaml
@@ -53,7 +53,7 @@ description: |
 
   If you want to preview an Animation before uploading it to the Roblox site,
   you can generate a temporary id using
-  `AnimationClipProvider:RegisterAnimationClip`. This generates a hash
+  `Class.AnimationClipProvider:RegisterAnimationClip()`. This generates a hash
   id that you can use for localized animation testing.
 
   ## Obtaining CurveAnimations
@@ -61,7 +61,7 @@ description: |
   As for other `Class.AnimationClip` types (such as `Class.KeyframeSequence`),
   if you want to download the CurveAnimation corresponding to an existing
   uploaded Animation using Luau scripts, use
-  AnimationClipProvider:AnimationClipAsync.
+  `Class.AnimationClipProvider:GetAnimationClipAsync()`.
 code_samples: []
 inherits:
   - AnimationClip

--- a/content/en-us/reference/engine/classes/CurveAnimation.yaml
+++ b/content/en-us/reference/engine/classes/CurveAnimation.yaml
@@ -53,7 +53,7 @@ description: |
 
   If you want to preview an Animation before uploading it to the Roblox site,
   you can generate a temporary id using
-  `AnimationClipProviderProvider:RegisterAnimationClip`. This generates a hash
+  `AnimationClipProvider:RegisterAnimationClip`. This generates a hash
   id that you can use for localized animation testing.
 
   ## Obtaining CurveAnimations

--- a/content/en-us/reference/engine/classes/CurveAnimation.yaml
+++ b/content/en-us/reference/engine/classes/CurveAnimation.yaml
@@ -5,62 +5,56 @@ summary: |
   Stores animation data in the form of curves for each individual channel to
   animate.
 description: |
-  CurveAnimation is a subtype of `Class.AnimationClip` consumed by Roblox's
-  animation system. It stores animation data for each animated channel in a Rig
-  as a separate, individual curve. For example, CurveAnimation stores the
-  Position channel for an articulated joint as `Class.Vector3Curve`, and it
-  might store the Rotation channel as an `Class.EulerRotationCurve` or a
+  `CurveAnimation` is a subtype of `Class.AnimationClip` consumed by Roblox's
+  animation system. It stores animation data for each animated channel in a rig
+  as a separate, individual curve. For example, `CurveAnimation` stores the
+  position channel for an articulated joint as a `Class.Vector3Curve`, and it
+  might store the rotation channel as a `Class.EulerRotationCurve` or
   `Class.RotationCurve`.
 
-  ## CurveAnimation structure
+  #### Structure
 
-  CurveAnimation stores curves in a hierarchical manner, matching the hierarchy
+  `CurveAnimation` stores curves in a hierarchical manner, matching the hierarchy
   of the structure of `Class.Motor6D|Motor6Ds` or `Class.Bone|Bones` in the
-  animated model. Under each CurveAnimation instance lies a hierarchy of
+  animated model. Under each `CurveAnimation` instance lies a hierarchy of
   `Class.Folder` instances representing animated joints in the model. Under each
   such folder instance, several possible instances may exist. An instance named
-  'Position' of type `Class.Vector3Curve` can drive the local translation of the
-  `Class.Motor6D` or `Class.Bone` on the animated model. Similarly, an instance
-  named 'Rotation', of type either `Class.EulerRotationCurve` or
+  `Position` of type `Class.Vector3Curve` can drive the local translation of the
+  `Class.Motor6D` or `Class.Bone` on the animated model, while an instance
+  named `Rotation` of type `Class.EulerRotationCurve` or
   `Class.RotationCurve` can drive the local rotation of the `Class.Motor6D` or
   `Class.Bone` on the animated model.
 
-  ## Partial matching of hierarchy
+  #### Partial matching of hierarchy
 
-  You can match partial hierarchies to a model when playing a CurveAnimation in
+  You can match partial hierarchies to a model when playing a `CurveAnimation` in
   Roblox's animation system. This means that not all joints need to be present
-  in the hierarchy for the joints that are present to apply properly.
-  Furthermore, you can match hierarchies in a 'relative' manner. For example, a
-  CurveAnimation's first `Class.Folder` instance root can be `UpperTorso`, and
+  in the hierarchy for the existing joints to apply properly.
+  Furthermore, you can match hierarchies in a "relative" manner. For example,
+  the first child `Class.Folder` instance root can be `UpperTorso` and
   the animation system matches that to any existing sub-hierarchies in the
   model.
 
-  ## Animating miscellaneous channels
+  #### Animating miscellaneous channels
 
-  Curve Animations can also animate other numerical values in a model. For
+  `CurveAnimation` can also animate other numerical values in a model. For
   example, you can animate FACS controls for facial animations by creating a
-  folder under the CurveAnimation instance named after an existing
+  `Class.Folder` under the `CurveAnimation` instance named after an existing
   `Class.FaceControls` instance in the model. Then, to animate individual facial
   controllers, you can store individual `Class.FloatCurve` instances named after
   the animated `Class.FaceControls` property.
 
-  ## Using CurveAnimation when making animations
+  #### Usage when making animations
 
-  As for other AnimationClip types (such as `Class.KeyframeSequence`), you must
-  upload CurveAnimations to Roblox first before playing them. To do that, right
-  click on the CurveAnimation and click 'Save to Roblox'. Alternatively, use
-  `Class.Plugin:SaveSelectedToRoblox()` to bring up the animation upload window.
+  As with other `Class.AnimationClip` types such as `Class.KeyframeSequence`,
+  you must first upload `CurveAnimation` instances to Roblox before playing them.
+  If you want to preview an animation before uploading it to Roblox,
+  you can generate a temporary ID using
+  `Class.AnimationClipProvider:RegisterAnimationClip()`; this generates a hash
+  ID that you can use for localized animation testing.
 
-  If you want to preview an Animation before uploading it to the Roblox site,
-  you can generate a temporary id using
-  `Class.AnimationClipProvider:RegisterAnimationClip()`. This generates a hash
-  id that you can use for localized animation testing.
-
-  ## Obtaining CurveAnimations
-
-  As for other `Class.AnimationClip` types (such as `Class.KeyframeSequence`),
-  if you want to download the CurveAnimation corresponding to an existing
-  uploaded Animation using Luau scripts, use
+  If you want to download the `CurveAnimation` corresponding to an existing
+  uploaded animation using Luau scripts, use
   `Class.AnimationClipProvider:GetAnimationClipAsync()`.
 code_samples: []
 inherits:


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->

Fixes typos on the documentation for CurveAnimation.
- Fixes "AnimationClipProviderProvider:RegisterAnimationClip" to "\`AnimationClipProvider:RegisterAnimationClip()\`"
- Fixes "\`AnimationClipProvider:AnimationClipAsync\`" to "\`AnimationClipProvider:GetAnimationClipAsync()\`"
- These add backquotes and parentheses to make these link to other parts of the wiki correctly.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
