### PR TITLE
Document InputObject behavior in CAS action functions

### DIFF
--- a/content/en-us/reference/engine/classes/ContextActionService.yaml
+++ b/content/en-us/reference/engine/classes/ContextActionService.yaml
@@ -149,23 +149,23 @@ methods:
       <tr>
         <td>1</td>
         <td><code>string</code></td>
-        <td>The same string that was originally passed to BindAction. This allows
-        one function to handle multiple actions at once, if necessary.</td>
+        <td>The same string that was originally passed to <code>Class.ContextActionService:BindAction()|BindAction()</code>.
+        This allows one function to handle multiple actions at once, if necessary.</td>
       </tr>
       <tr>
         <td>2</td>
         <td><code>Enum.UserInputState</code></td>
-        <td>The state of the input (Begin, Change, End or Cancel). Cancel is sent
-        if some input was in-progress and another action bound over the in-progress
-        input, or if the in-progress bound action was `Class.ContextActionService:UnbindAction()|unbound`.</td>
+        <td>The state of the input. <code>Enum.UserInputState|Cancel</code> is sent
+        if some input was in progress and another action bound over that in-progress
+        input, or if the in-progress bound action was unbound through <code>Class.ContextActionService:UnbindAction()|UnbindAction()</code>.</td>
       </tr>
       <tr>
         <td>3</td>
         <td><code>InputObject</code></td>
         <td>An object that contains information about the input (varies based on
-        UserInputType). The InputObject sometimes won't match the inputs the action
-        was bound to: when the Cancel state is sent, this object will have KeyCode
-        `Enum.KeyCode.Unknown|Unknown` and UserInputType `Enum.UserInputType.None|None`.</td>
+        <code>Enum.UserInputType</code>). The <code>Class.InputObject</code> sometimes won't match the inputs the action
+        was bound to: when the <code>Enum.UserInputState|Cancel</code> state is sent, this object will be
+        <code>Enum.KeyCode.Unknown</code> and <code>Enum.UserInputType.None</code>.</td>
       </tr>
       </table>
 

--- a/content/en-us/reference/engine/classes/ContextActionService.yaml
+++ b/content/en-us/reference/engine/classes/ContextActionService.yaml
@@ -149,24 +149,25 @@ methods:
       <tr>
         <td>1</td>
         <td><code>string</code></td>
-        <td>The same string that was originally passed to BindAction†</td>
+        <td>The same string that was originally passed to BindAction. This allows
+        one function to handle multiple actions at once, if necessary.</td>
       </tr>
       <tr>
         <td>2</td>
         <td><code>Enum.UserInputState</code></td>
-        <td>The state of the input (Begin, Change, End or Cancel)*</td>
+        <td>The state of the input (Begin, Change, End or Cancel). Cancel is sent
+        if some input was in-progress and another action bound over the in-progress
+        input, or if the in-progress bound action was `Class.ContextActionService:UnbindAction()|unbound`.</td>
       </tr>
       <tr>
         <td>3</td>
         <td><code>InputObject</code></td>
-        <td>An object that contains information about the input (varies based on UserInputType)</td>
+        <td>An object that contains information about the input (varies based on
+        UserInputType). The InputObject sometimes won't match the inputs the action
+        was bound to: when the Cancel state is sent, this object will have KeyCode
+        `Enum.KeyCode.Unknown|Unknown` and UserInputType `Enum.UserInputType.None|None`.</td>
       </tr>
       </table>
-
-      † This allows one function to handle multiple actions at once, if
-      necessary. \*Cancel is sent if some input was in-progress and another
-      action bound over the in-progress input, or if the in-progress bound
-      action was `Class.ContextActionService:UnbindAction()|unbound`.
 
       #### Action Bindings Stack
 


### PR DESCRIPTION
## Changes

- Document how the InputObject passed to a ContextActionService action function won't correspond to a bound input when the function is called with Cancel state.
- Since every entry in the table of function parameters would have an extra detail/note about it, it seemed unnecessary to keep those notes outside of the table, so they have been put in to the table.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
