### PR TITLE
deepFreeze recursive function nil ref s/v/value

### DIFF
--- a/content/en-us/luau/tables.md
+++ b/content/en-us/luau/tables.md
@@ -347,7 +347,7 @@ local function deepFreeze(target)
 	for _, value in target do
 		-- Make sure the value isn't frozen; if it already is, an error will occur
 		if type(value) == "table" and table.isfrozen(value) == false then
-			deepFreeze(v)
+			deepFreeze(value)
 		end
 	end
 end


### PR DESCRIPTION
## Changes

The deepFreeze() recursive example function used an invalid `v` local instead of `value`.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
