### PR TITLE
Update Mouse.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/Mouse.yaml
+++ b/content/en-us/reference/engine/classes/Mouse.yaml
@@ -121,7 +121,7 @@ properties:
     capabilities:
       - Input
     writeCapabilities: []
-  - name: Mouse.Icon
+  - name: Mouse.
     summary: |
       The content ID of the image used as the `Class.Mouse` icon.
     description: |
@@ -142,6 +142,7 @@ properties:
       cursors:
 
       - The dimensions of the image used determines the size of the cursor.
+      - The dimensions of the image should not exceed 256 pixels on any axis.
       - The **center** of the image is where mouse inputs are issued.
       - The default mouse image is 64x64 pixels, with the mouse taking up 17x24
         pixels of space.


### PR DESCRIPTION
This adds extra information on image compatibility requirements for mouse icons.

## Changes

Notes that the image size is required to be smaller than 256x256 for a mouse icon image.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
