### PR TITLE
Enum.ItemType to Enum.AvatarItemType

### DIFF
--- a/content/en-us/reference/engine/classes/AvatarEditorService.yaml
+++ b/content/en-us/reference/engine/classes/AvatarEditorService.yaml
@@ -506,7 +506,7 @@ methods:
     description: |
       This function returns the item details for the given item. It accepts two
       parameters - the first indicating the ID of the item being retrieved and
-      the second indicating its `Enum.ItemType`.
+      the second indicating its `Enum.AvatarItemType`.
 
       Data returned in the format:
 


### PR DESCRIPTION
Old Enum.ItemType reference changed into Enum.AvatarItemType

## Changes

<!-- Please summarize your changes. -->
Enum.ItemType seems to have been changed into Enum.AvatarItemType. This line was outdated.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
