### PR TITLE
Relocate ProcessReceipt API notes

### DIFF
--- a/content/en-us/production/monetization/developer-products.md
+++ b/content/en-us/production/monetization/developer-products.md
@@ -46,13 +46,6 @@ To use scripting, you need a developer product ID. To get the product ID:
 If you're using [price optimization](./price-optimization.md), make sure to place the script inside a `Class.LocalScript` so that users see personalized product prices.
 </Alert>
 
-Before selling developer products, make sure you are properly processing sales receipts and granting users their purchased products. To do so, you must:
-
-- Use the `Class.MarketplaceService.ProcessReceipt|ProcessReceipt` API to check purchase receipts. `ProcessReceipt` automatically reads and acknowledges that a user has purchased a product outside of the experience.
-- Validate each receipt for `User ID`, `Developer Product ID`, and the receipt status.
-- If the receipt has a status of **Open**, grant the user the developer items they have purchased.
-- Respond to the `ProcessReceipt` API with a message acknowledging the receipt and validating that the purchased items were granted.
-
 You can sell developer products in two ways:
 
 - [Inside your experience](#inside-your-experience)
@@ -158,7 +151,14 @@ end)
 
 ### Outside your experience
 
-To enable developer product purchases outside your experience, you must work with the `Class.MarketplaceService.ProcessReceipt|ProcessReceipt` API. After a user makes a purchase in the **Store** tab of your experience details page, you must use `ProcessReceipt` to confirm their purchase and grant them their items once they enter your experience.
+To enable developer product purchases outside of your experience, you must work with the `Class.MarketplaceService.ProcessReceipt|ProcessReceipt` API. 
+
+After a user purchases a developer item in the **Store** tab of your experience page, you must:
+
+- Use the `Class.MarketplaceService.ProcessReceipt|ProcessReceipt` API to check purchase receipts. `ProcessReceipt` automatically reads and acknowledges that a user has purchased a product outside of the experience.
+- Validate each receipt for `User ID`, `Developer Product ID`, and the receipt status.
+- If the receipt has a status of **Open**, grant the user the developer items they have purchased.
+- Respond to the `ProcessReceipt` API with a message acknowledging the receipt and validating that the purchased items were granted.
 
 <Alert severity="warning">
 Do **not** use the `Class.MarketplaceService:PromptProductPurchaseFinished|PromptProductPurchaseFinished` event to process purchases. You must use the `ProcessReceipt` callback instead.


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
**Updated document for readability and improved organization.** 

Moved the ProcessReceipt API comments from below the header of "Sell your developer product" to it's appropriate location, "Outside your experience." This is to avoid misleading developers into believing that ProcessReceipt is required for all transactions, when it is actually only required for transactions outside of the experience. Also improved some verbiage for better readability.

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [✅] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [✅] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [✅] To the best of my knowledge, all proposed changes are accurate.
