### PR TITLE
Update Character Loading Event Order

### DIFF
--- a/content/en-us/reference/engine/classes/Player.yaml
+++ b/content/en-us/reference/engine/classes/Player.yaml
@@ -2439,17 +2439,17 @@ methods:
 
       #### Character Loading Event order
 
-      Calling the `Class.Player:LoadCharacter()` on any Player fires events
+      Calling the `Class.Player:LoadCharacter()` method on any `Class.Player` fires events
       in the following order:
-
-      1. Character appearance initializes
-      2. The Character rig builds, and the Character scales
-      3. Character moves to the spawn location
-      4. Player.Character sets
+      
+      1. The character appearance initializes.
+      2. The character rig builds and scales.
+      3. The character moves to the spawn location.
+      4. `Class.Player.Character` sets.
       5. Player.Changed fires with a value of "Character"
       6. Character.Parent sets to the DataModel
-      7. Player.CharacterAdded fires
-      8. Player.CharacterAppearanceLoaded fires
+      7. `Class.Player.CharacterAdded` fires.
+      8. `Class.Player.CharacterAppearanceLoaded` fires.
       9. LoadCharacter returns
     code_samples:
       - Player-LoadCharacter1

--- a/content/en-us/reference/engine/classes/Player.yaml
+++ b/content/en-us/reference/engine/classes/Player.yaml
@@ -2442,6 +2442,16 @@ methods:
       Calling the `Class.Player:LoadCharacter()` with an R15 Avatar fires events
       in the following order (Note: R6 ordering is different):
 
+      1. Character appearance initializes
+      2. The Character rig builds, and the Character scales
+      3. Character moves to the spawn location
+      4. Player.Character sets
+      5. Player.Changed fires with a value of "Character"
+      6. Character.Parent sets to the DataModel
+      7. Player.CharacterAdded fires
+      8. Player.CharacterAppearanceLoaded fires
+      9. LoadCharacter returns
+
       1. Player.Character sets
       2. Player.CharacterAdded fires
       3. Player.Changed fires with a value of "Character"

--- a/content/en-us/reference/engine/classes/Player.yaml
+++ b/content/en-us/reference/engine/classes/Player.yaml
@@ -2439,8 +2439,8 @@ methods:
 
       #### Character Loading Event order
 
-      Calling the `Class.Player:LoadCharacter()` with an R15 Avatar fires events
-      in the following order (Note: R6 ordering is different):
+      Calling the `Class.Player:LoadCharacter()` on any Player fires events
+      in the following order:
 
       1. Character appearance initializes
       2. The Character rig builds, and the Character scales
@@ -2450,16 +2450,6 @@ methods:
       6. Character.Parent sets to the DataModel
       7. Player.CharacterAdded fires
       8. Player.CharacterAppearanceLoaded fires
-      9. LoadCharacter returns
-
-      1. Player.Character sets
-      2. Player.CharacterAdded fires
-      3. Player.Changed fires with a value of "Character"
-      4. Character appearance initializes
-      5. Player.CharacterAppearanceLoaded fires
-      6. Character.Parent sets to the DataModel
-      7. The Character rig builds, and the Character scales
-      8. Character moves to the spawn location
       9. LoadCharacter returns
     code_samples:
       - Player-LoadCharacter1


### PR DESCRIPTION
## Changes
I updated the Character Loading Event Order to reflect a roblox update from 2019 that changes the order in which the Character Loads.

Relevant Update:
https://devforum.roblox.com/t/avatar-loading-event-ordering-improvements/269607

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
