### PR TITLE
Update Player CharacterAppearanceLoaded

### DIFF
--- a/content/en-us/reference/engine/classes/Player.yaml
+++ b/content/en-us/reference/engine/classes/Player.yaml
@@ -2696,6 +2696,9 @@ events:
       objects have been inserted into the `Class.Player.Character`.
 
       This event only fires on the server.
+      
+      For custom character implementations, such as using a `Class.StarterPlayer|StarterCharacter`,
+      Use `Class.Player.CharacterAdded` and handle your own accessories.
 
       One use for this event is to ensure all accessories have loaded before
       destroying them. See below for an example of this.


### PR DESCRIPTION
When using custom character implementations such as using a StarterCharacter, people should handle the character appearance themselves. This serves as a note, a warning that CharacterAppearanceLoaded does not fire for custom characters.

## Changes

<!-- Please summarize your changes. -->
Added an additional note for when this event (`CharacterAppearanceLoaded`) should not be used (such as using StarterCharacters), because it will not fire and I think this note will save a lot of people from headache debugging.
```
      For custom character implementations, such as using a `Class.StarterPlayer|StarterCharacter`,
      Use `Class.Player.CharacterAdded` and handle your own accessories.
```

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->
Reference: 
https://devforum.roblox.com/t/playercharacterappearanceloaded-does-not-fire-if-there-is-a-startercharacter-present/3684116

## Checks

By submitting your pull request for review, you agree to the following:

- [✅] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [✅ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [✅ ] To the best of my knowledge, all proposed changes are accurate.
