### PR TITLE
ADHOC: Github workflow is vulnerable to command injection via Pull request branch name

### DIFF
--- a/.github/workflows/content-checks.yml
+++ b/.github/workflows/content-checks.yml
@@ -63,14 +63,22 @@ jobs:
         run: npm ci
 
       - name: Print workflow information
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Pull request number: ${{ github.event.pull_request.number }}"
-          echo "Pull request user login: ${{ github.event.pull_request.user.login }}"
-          echo "Base (target) ref: ${{ github.event.pull_request.base.ref }}"
-          echo "Base (target) sha: ${{ github.event.pull_request.base.sha }}"
-          echo "Head (source) ref: ${{ github.event.pull_request.head.ref }}"
-          echo "Head (source) sha: ${{ github.event.pull_request.head.sha }}"
+          echo "Event name: $EVENT_NAME"
+          echo "Pull request number: $PR_NUMBER"
+          echo "Pull request user login: $PR_USER_LOGIN"
+          echo "Base (target) ref: $BASE_REF"
+          echo "Base (target) sha: $BASE_SHA"
+          echo "Head (source) ref: $HEAD_REF"
+          echo "Head (source) sha: $HEAD_SHA"
           git status
           git remote -v
           git log --oneline -n 10


### PR DESCRIPTION
To address this issue: https://roblox.atlassian.net/browse/BUGBOUNTY-1288

## Changes
1. Use Environment Variables: Move all the GitHub Actions expressions to the `env` section of the step
2. Reference via Shell Variables: In the shell script, reference these as `$VARIABLE_NAME` instead of direct interpolation

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
