### PR TITLE
Tiny fix in Enums, stray ')' character

### DIFF
--- a/content/en-us/reference/engine/datatypes/Enums.yaml
+++ b/content/en-us/reference/engine/datatypes/Enums.yaml
@@ -4,7 +4,7 @@ summary: |
   A root access point of all `Datatype.Enum|Enums`.
 description: |
   The `Datatype.Enums` data type, more commonly known as `Datatype.Enum` by its
-  global variable in Luau), acts as the root access point for all available
+  global variable in Luau, acts as the root access point for all available
   enums on Roblox. All enums on Roblox are indexed via their name through this
   data type, and developers can also utilize the `GetEnums()` method to get a
   list of all enums on Roblox.


### PR DESCRIPTION
## Changes

Enums page had a stray ')' character.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
