### PR TITLE
Remove incorrect statement

### DIFF
--- a/content/en-us/reference/engine/classes/Players.yaml
+++ b/content/en-us/reference/engine/classes/Players.yaml
@@ -892,8 +892,8 @@ methods:
     summary: |
       Returns information about the character appearance of a given user.
     description: |
-      This function returns information about a player's avatar (ignoring gear)
-      on the Roblox website in the form of a dictionary. It is not to be
+      This function returns information about a player's avatar on
+      the Roblox website in the form of a dictionary. It is not to be
       confused with
       `Class.Players:GetCharacterAppearanceAsync()|GetCharacterAppearanceAsync`,
       which actually loads the assets described by this method. You can use


### PR DESCRIPTION
Removes the incorrect statement that `Players:GetCharacterAppearanceInfoAsync` ignores gear.

Testing shows that gear is included in the returned `assets` table. This change makes the documentation accurate.

## Changes

<img width="626" height="416" alt="image" src="https://github.com/user-attachments/assets/896e27d8-ebe1-4a27-a65d-f4642125fb22" />

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
