### PR TITLE
Fix “Robox” Typos

### DIFF
--- a/content/en-us/matchmaking/scoring.md
+++ b/content/en-us/matchmaking/scoring.md
@@ -195,7 +195,7 @@ ServerScore
 
 A matchmaking configuration is the set of signals and weights used to score servers of a place. By default, all servers of all places are scored by the Roblox default configuration, meaning you don't need to customize or enable any settings in order to use it.
 
-The Robox default configuration includes the following signals and weights:
+The Roblox default configuration includes the following signals and weights:
 
 <table>
 <thead>

--- a/content/en-us/scripting/index.md
+++ b/content/en-us/scripting/index.md
@@ -1,6 +1,6 @@
 ---
 title: Scripting
-description: An introduction to scripting in Robox with the Luau programming language.
+description: An introduction to scripting in Roblox with the Luau programming language.
 ---
 
 Scripts are plain text files that let you add custom, dynamic behavior to your experiences. You can use scripts to trigger in-game events, respond to player input, save player data, create leaderboards, spawn enemies, control NPC behavior, and much, much more.


### PR DESCRIPTION
## Changes
Fixes instances of “Roblox” that are misspelt as “Robox”, that is all!

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
