### PR TITLE
Replaced "Discover" with "Charts" and removed old categories

### DIFF
--- a/content/en-us/production/promotion/nominate-for-the-discover-page.md
+++ b/content/en-us/production/promotion/nominate-for-the-discover-page.md
@@ -1,12 +1,12 @@
 ---
-title: Nominate for the Discover page
-description: Explains the process of nominating your experience for specialized sort categories on the Discover page.
+title: Nominate for the Charts page
+description: Explains the process of nominating your experience for specialized sort categories on the Charts page.
 ---
 
 Sorts are collections of experiences that users see when they are
 browsing the
-[Discover](https://www.roblox.com/discover#/) page,
-such as **Most Engaging**, **Up-and-Coming**, and **Roleplay**. While most sorts generate automatically, you can nominate your experiences to the
+[Charts](https://www.roblox.com/charts#/) page,
+such as **Top Trending**, **Up-and-Coming**, and **Most Popular**. While most sorts generate automatically, you can nominate your experiences to the
 [Learn & Explore](#learn--explore-criteria) sort. Experiences you nominate
 should have a consistent and active user base, be well-liked by the community,
 and remain public to all users. Consequently, paid


### PR DESCRIPTION
## Changes
It's been a while since it's been "Charts" instead of "Discover", and I removed "Most Engaging" and "Roleplay" since they no longer exist on the Charts page.

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
