### PR TITLE
Revert my previous change to restore the original collision group example

### DIFF
--- a/content/en-us/workspace/collisions.md
+++ b/content/en-us/workspace/collisions.md
@@ -270,27 +270,27 @@ interesting but unintended gameplay, such as characters jumping on top of each o
 local PhysicsService = game:GetService("PhysicsService")
 local Players = game:GetService("Players")
 
-local CollisionGroupName = "Characters"
-PhysicsService:RegisterCollisionGroup(CollisionGroupName)
-PhysicsService:CollisionGroupSetCollidable(CollisionGroupName, CollisionGroupName, false)
+PhysicsService:RegisterCollisionGroup("Characters")
+PhysicsService:CollisionGroupSetCollidable("Characters", "Characters", false)
 
-local function setCollisionGroup(model)
-  -- Apply collision group to all existing parts in the model
-  for _, descendant in model:GetDescendants() do
-    if descendant:IsA("BasePart") then
-      descendant.CollisionGroup = CollisionGroupName
-    end
-  end
+local function onDescendantAdded(descendant)
+	-- Set collision group for any part descendant
+	if descendant:IsA("BasePart") then
+		descendant.CollisionGroup = "Characters"
+	end
+end
+
+local function onCharacterAdded(character)
+	-- Process existing and new descendants for physics setup
+	for _, descendant in character:GetDescendants() do
+		onDescendantAdded(descendant)
+	end
+	character.DescendantAdded:Connect(onDescendantAdded)
 end
 
 Players.PlayerAdded:Connect(function(player)
-  player.CharacterAdded:Connect(function(character)
-    setCollisionGroup(character)
-  end)
-  -- If the player already has a character, apply the collision group immediately
-  if player.Character then
-    setCollisionGroup(player.Character)
-  end
+	-- Detect when the player's character is added
+	player.CharacterAdded:Connect(onCharacterAdded)
 end)
 ```
 


### PR DESCRIPTION
## Changes
Reverting my change (https://github.com/Roblox/creator-docs/pull/984) because the original example is clearer and handles all cases better. It properly sets collision groups for parts added after the character spawns, which my version didn’t cover. This makes the official documentation more complete and easier to understand.

Regarding performance, the difference is minimal for most use cases, but the original version is safer as it handles dynamic parts correctly without impacting performance noticeably

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
