### PR TITLE
Add alert to typechecking docs page informing readers of luaus offical typechecking docs

### DIFF
--- a/content/en-us/luau/type-checking.md
+++ b/content/en-us/luau/type-checking.md
@@ -3,6 +3,9 @@ title: Type checking
 description: Luau uses gradual typing through the use of type annotations and inference.
 ---
 
+<Alert severity="info">
+More up to date documentation can be found at https://luau.org/typecheck
+</Alert>
 Luau supports a gradual type system through the use of type annotations and type inference. These types are used to provide better warnings, errors, and suggestions in the [Script Editor](../studio/script-editor.md).
 
 ## Define a type


### PR DESCRIPTION
## Changes

The typechecking docs page now refers readers to luaus official type checking docs for a more up to date reference. As robloxs docs site is very clearly lagging behind currently, this isn't intended to be a replacement for the typechecking docs page but rather a way to give readers more up to date info in case its still lagging behind in future.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
