### PR TITLE
Fix luau url in luau docs

### DIFF
--- a/content/en-us/luau/index.md
+++ b/content/en-us/luau/index.md
@@ -3,7 +3,7 @@ title: Luau
 description: Luau is the scripting language creators use in Roblox Studio.
 ---
 
-[Luau](https://luau-lang.org) is the scripting language creators use in Roblox Studio. It is a fast, small, safe, gradually typed embeddable scripting language derived from [Lua 5.1](https://www.lua.org/manual/5.1/).
+[Luau](https://luau.org) is the scripting language creators use in Roblox Studio. It is a fast, small, safe, gradually typed embeddable scripting language derived from [Lua 5.1](https://www.lua.org/manual/5.1/).
 
 <Alert severity="success">
 Contributing your Luau scripts for AI training can help enhance Luau-focused AI tools in Studio. For more information, see [Empower Luau creation](https://create.roblox.com/data-collection).


### PR DESCRIPTION
## Changes

Fixes luau url pointing to https://luau-lang.org instead of https://luau.org

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
