### PR TITLE
Update UIPageLayout.yaml

### DIFF
--- a/content/en-us/reference/engine/classes/UIPageLayout.yaml
+++ b/content/en-us/reference/engine/classes/UIPageLayout.yaml
@@ -308,9 +308,9 @@ methods:
 events:
   - name: UIPageLayout.PageEnter
     summary: |
-      Fires when a page comes into view, and is going to be rendered.
+      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     description: |
-      Fires when a page comes into view, and is going to be rendered.
+      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     code_samples: []
     parameters:
       - name: page
@@ -324,9 +324,9 @@ events:
       - UI
   - name: UIPageLayout.PageLeave
     summary: |
-      Fires when a page leaves view, and will not be rendered.
+      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     description: |
-      Fires when a page leaves view, and will not be rendered.
+      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     code_samples: []
     parameters:
       - name: page

--- a/content/en-us/reference/engine/classes/UIPageLayout.yaml
+++ b/content/en-us/reference/engine/classes/UIPageLayout.yaml
@@ -308,9 +308,13 @@ methods:
 events:
   - name: UIPageLayout.PageEnter
     summary: |
-      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
+      Fires when a page comes into view, has its visible property toggled on, and is going to be rendered. This will never fire if `GuiObject.ClipsDescendants` is set to false for its parent and may trigger multiple times depending on the animation used.
+      
+      In order to listen to a page index changes, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     description: |
-      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
+      Fires when a page comes into view, has its visible property toggled on, and is going to be rendered. This will never fire if `GuiObject.ClipsDescendants` is set to false for its parent and may trigger multiple times depending on the animation used.
+      
+      In order to listen to a page index changes, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     code_samples: []
     parameters:
       - name: page
@@ -324,9 +328,13 @@ events:
       - UI
   - name: UIPageLayout.PageLeave
     summary: |
-      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
+      Fires when a page leaves view, has its visible property toggled off, and is no longer going to be rendered. This will never fire if `GuiObject.ClipsDescendants` is set to false for its parent and may trigger multiple times depending on the animation used.
+      
+      In order to listen to a page index changes, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     description: |
-      Fires when a page comes into view, becomes visible, and is going to be rendered. In order to listen to changes in pageIndex, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
+      Fires when a page leaves view, has its visible property toggled off, and is no longer going to be rendered. This will never fire if `GuiObject.ClipsDescendants` is set to false for its parent and may trigger multiple times depending on the animation used.
+      
+      In order to listen to a page index changes, connect to `:GetPropertyChangedSignal("CurrentPage")` instead.
     code_samples: []
     parameters:
       - name: page


### PR DESCRIPTION
### Why are the changes being made?

## Changes

In order to follow up with this [DevForum bug report](https://devforum.roblox.com/t/uipagelayoutpageenter-and-uipagelayoutpageleave-events-do-not-trigger/3837403), I'm updating documentation surround UIPageLayout to be more descriptive. More specifically, I've updated the description for the `PageEnter` and `PageLeave` events, to state that they are only used to determine whether a page has become visible on the screen.

It also provides an alternative method for determining when a page has changed (which is likely to apply to a lot of, if not most developers.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.

### What changes are being made?

- Clarifies `UIPageLayout.PageEnter` and `PageLeave` event docs in `UIPageLayout.yaml`, explaining visibility, rendering, and alternatives for page change detection.
---
- [ ] AI-assisted summary reviewed and verified by author