### PR TITLE
Update group payouts eligibility to mention age check

### DIFF
--- a/content/en-us/projects/groups.md
+++ b/content/en-us/projects/groups.md
@@ -231,7 +231,7 @@ To remove a member entirely, hover over their name and click the "trash" button.
 If you're the owner of a selected group, you'll find a **Payouts** page under **Finances**. Here, you can send one‑time payouts, as well as define percentage splits with other members.
 
 <Alert severity="info">
-Some groups may not have this page unlocked initially for various reasons, such as the group having no funds to payout.
+Some groups may not have this page unlocked initially for various reasons, such as insufficient funds or the age of the group.
 </Alert>
 
 <Alert severity="warning">


### PR DESCRIPTION
We sometimes get devforum reports about groups not being able to use group payouts, but they are unsure why. Although the existing error message does mention the age of the group is a check, the docs do not make this same mention. Adding it here for consistency

Example Report:
https://devforum.roblox.com/t/group-pay-outs-taking-4-weeks/3593388

Current error message mentions this:
[Group Name] is currently restricted from using one-time and recurring payments. This may be due to insufficient funds, the age of the group, or something else. Please check back later.


## Changes

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
