### PR TITLE
Add JSONEncode supporting buffers

### DIFF
--- a/content/en-us/reference/engine/classes/HttpService.yaml
+++ b/content/en-us/reference/engine/classes/HttpService.yaml
@@ -238,9 +238,12 @@ methods:
       - The value `nil` is never generated.
       - Cyclic table references cause an error.
 
-        This method allows values such as `inf` and `nan` which are not valid
-        JSON. This may cause problems if you want to use the outputted JSON
-        elsewhere.
+      This method allows values such as `inf` and `nan` which are not valid
+      JSON. This may cause problems if you want to use the outputted JSON
+      elsewhere.
+
+      This method can also take a `Datatype.buffer`, which will compress and
+      encode the buffer to Base64, before turning it into a JSON object.
 
       To reverse the encoding process and decode a JSON object, use the
       `Class.HttpService:JSONDecode()` method.


### PR DESCRIPTION
## Changes

Adds a previously undocumented note about `buffer` being supported in JSONEncode, which returns a compressed and encoded variant of the buffer.

I'm unsure if `Base64` in this addition is formatted correctly to style.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
