### PR TITLE
Update GuiService Documentation to Fix Mismatched Reference

### DIFF
--- a/content/en-us/reference/engine/classes/GuiService.yaml
+++ b/content/en-us/reference/engine/classes/GuiService.yaml
@@ -713,7 +713,7 @@ methods:
       a descendant of PlayerGui, the engine searches all available selectable,
       visible and on-screen GuiObjects that are descendants of selectionParent
       and sets the `Class.GuiService.SelectedObject` to the GuiObject with the
-      smallest `Class.GuiService.SelectionOrder`.
+      smallest `Class.GuiObject.SelectionOrder`.
     code_samples:
       - GuiService-PreferredTransparency
     parameters:


### PR DESCRIPTION
Fixes mistake where `GuiService.SelectionOrder` was referenced instead of `GuiObject.SelectionOrder`

## Changes

`GuiService.SelectionOrder` obviously doesn't exist, i am assuming that it was originally supposed to say `GuiObject.SelectionOrder`.
This request fixes this issue

When i came across this, i was decently confused by this at first then after a couple of minutes i realized it was a mistake which was a little annoying...

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
