### PR TITLE
Add references to FreeCam camera tilting keybinds

### DIFF
--- a/content/en-us/production/publishing/thumbnails.md
+++ b/content/en-us/production/publishing/thumbnails.md
@@ -205,6 +205,10 @@ Once in free camera mode, you can use the following controls:
     <td>Moves the camera down/up.</td>
   </tr>
   <tr>
+    <td><kbd>Z</kbd> <kbd>C</kbd></td>
+    <td>Tilts the camera left/right in the appropriate direction</td>
+  </tr>
+  <tr>
     <td><kbd>Shift</kbd></td>
     <td>In combination with any movement key, changes the camera speed.</td>
   </tr>

--- a/content/en-us/production/publishing/thumbnails.md
+++ b/content/en-us/production/publishing/thumbnails.md
@@ -206,7 +206,7 @@ Once in free camera mode, you can use the following controls:
   </tr>
   <tr>
     <td><kbd>Z</kbd> <kbd>C</kbd></td>
-    <td>Tilts the camera left/right in the appropriate direction</td>
+    <td>Tilts the camera left/right in the appropriate direction.</td>
   </tr>
   <tr>
     <td><kbd>Shift</kbd></td>

--- a/content/en-us/production/publishing/thumbnails.md
+++ b/content/en-us/production/publishing/thumbnails.md
@@ -206,7 +206,7 @@ Once in free camera mode, you can use the following controls:
   </tr>
   <tr>
     <td><kbd>Z</kbd> <kbd>C</kbd></td>
-    <td>Tilts the camera left/right in the appropriate direction.</td>
+    <td>Tilts the camera left/right (roll).</td>
   </tr>
   <tr>
     <td><kbd>Shift</kbd></td>


### PR DESCRIPTION
## Changes

- Added respective references to the key binds for the camera tilting feature, which can be accessed by the `Z` and `C` keys while actively inside of freecam.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
