### PR TITLE
SocialService: Fix typos in PromptLinkSharing Parameters

### DIFF
--- a/content/en-us/reference/engine/classes/SocialService.yaml
+++ b/content/en-us/reference/engine/classes/SocialService.yaml
@@ -381,9 +381,9 @@ methods:
             share link is created. Truncates to nearest integer. Defaults to
             86,400.
           - `PreviewTitle` (string) Preview title of the share link.
-          - `PreiviewDescription` (string) Preview description of the share
+          - `PreviewDescription` (string) Preview description of the share
             link.
-          - `PreviewAssettId` (number) Image asset ID used for share link
+          - `PreviewAssetId` (number) Image asset ID used for share link
             preview.
           - `LaunchData` (string). Used to set a parameter in
             `Class.Player:GetJoinData()` when a player joined using the


### PR DESCRIPTION
## Changes

This PR fixes two typos in the `options` parameters for PromptLinkSharing; `PreiviewDescription` and `PreviewAssettId`.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
