### PR TITLE
Fixing potential wrapping failure in parameters practice tutorial section

### DIFF
--- a/content/en-us/tutorials/fundamentals/coding-2/parameters-practice-buttons.md
+++ b/content/en-us/tutorials/fundamentals/coding-2/parameters-practice-buttons.md
@@ -22,6 +22,7 @@ Start off by setting up the bridge.
    - Uncheck **CanCollide**.
 
 4. When you test the experience, the bridge should be misty looking and people shouldn't be able to walk on it yet.
+
    <img src="../../../assets/education/coding-2/transparent-bridge.jpg" width="80%" />
 
 ## Create the button
@@ -32,7 +33,8 @@ Now that the bridge is set up, create the button.
 2. Change the button color to red.
 3. **Anchor** the button.
 4. Move the button so it's slightly floating and not touching anything. This is so to make sure the `Touched` event doesn't accidentally fire.
-   <img src="../../../assets/education/coding-2/red-button.jpg" width="80%" />
+
+	 <img src="../../../assets/education/coding-2/red-button.jpg"width="80%" />
 
 ## Make the button interactive
 


### PR DESCRIPTION
## Changes

I've added a tiny bit of spacing to the images and text of the tutorial, as the text and image have a slight wrapping failure on larger screen sizes.

Affected pages:
https://create.roblox.com/docs/tutorials/fundamentals/coding-2/parameters-practice-buttons

<img width="951" height="838" alt="Image of the issue" src="https://github.com/user-attachments/assets/52e9952f-a6a2-43b0-823a-fd426aac1c28" />

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
