### PR TITLE
Document RecommendationService:LogPreferenceEvent

### DIFF
--- a/content/en-us/reference/engine/classes/RecommendationService.yaml
+++ b/content/en-us/reference/engine/classes/RecommendationService.yaml
@@ -277,29 +277,76 @@ methods:
       - Basic
   - name: RecommendationService:LogPreferenceEvent
     summary: ''
-    description: ''
-    code_samples: []
+    description: |
+      This function logs a user preference signal directed at another user, a
+      universe, or a custom content tag. Preference signals include follow,
+      unfollow, mute, and unmute actions, and are used by the recommendation
+      engine to personalize future results for the user.
+
+      The `targetType` parameter determines how `targetId` is interpreted:
+
+      - For `Enum.RecommendationPreferenceTargetType.User|User`, `targetId` is
+        the user key of the target user.
+      - For `Enum.RecommendationPreferenceTargetType.Universe|Universe`,
+        `targetId` is the universe ID as a string.
+      - For `Enum.RecommendationPreferenceTargetType.CustomTag|CustomTag`,
+        `targetId` is the custom tag string.
+
+      When the preference originates from a feed item served by
+      `Class.RecommendationService.GenerateItemListAsync|GenerateItemListAsync`,
+      pass the corresponding `tracingId` and `itemId` so the event can be
+      correlated with the recommendation context. Both are optional because
+      preferences can also originate from profiles, search, or other surfaces
+      outside of a recommendation feed.
+
+      This function can only be called from the **client**.
+
+      **Note:** Only `LogPreferenceEvent` calls in production actually log
+      preferences. Calling this function in Studio doesn't have any effect; you
+      can call it as many times as you want when testing.
+    code_samples:
+      - LogPreferenceEvent-example
     parameters:
       - name: preferenceType
         type: RecommendationPreferenceType
         default:
-        summary: ''
+        summary: |
+          The type of preference being logged, such as
+          `Enum.RecommendationPreferenceType.AddFollow|AddFollow` or
+          `Enum.RecommendationPreferenceType.AddMute|AddMute`.
       - name: targetType
         type: RecommendationPreferenceTargetType
         default:
-        summary: ''
+        summary: |
+          The kind of entity `targetId` refers to. Determines how `targetId` is
+          interpreted.
       - name: targetId
         type: string
         default:
-        summary: ''
+        summary: |
+          The identifier of the preference target. The format depends on
+          `targetType`: a user key for
+          `Enum.RecommendationPreferenceTargetType.User|User`, the universe ID
+          as a string for
+          `Enum.RecommendationPreferenceTargetType.Universe|Universe`, or the
+          tag string for
+          `Enum.RecommendationPreferenceTargetType.CustomTag|CustomTag`.
       - name: tracingId
         type: string
         default:
-        summary: ''
+        summary: |
+          The tracing ID returned from the
+          `Class.RecommendationService.GenerateItemListAsync|GenerateItemListAsync`
+          response, if the preference originated from a recommended item. Pass
+          an empty string when the preference originates from outside a
+          recommendation feed.
       - name: itemId
         type: string
         default:
-        summary: ''
+        summary: |
+          The item ID of the recommended item that triggered the preference,
+          if any. Pass an empty string when the preference originates from
+          outside a recommendation feed.
     returns:
       - type: ()
         summary: ''

--- a/content/en-us/reference/engine/enums/RecommendationPreferenceTargetType.yaml
+++ b/content/en-us/reference/engine/enums/RecommendationPreferenceTargetType.yaml
@@ -4,24 +4,31 @@
 
 name: RecommendationPreferenceTargetType
 type: enum
-summary: ''
+summary: |
+  The kind of entity a preference signal targets when logged via
+  `Class.RecommendationService.LogPreferenceEvent|LogPreferenceEvent`.
+  Determines how the `targetId` parameter is interpreted.
 description: ''
 code_samples: []
 tags: []
 deprecation_message: ''
 items:
   - name: User
-    summary: ''
+    summary: |
+      The target is another Roblox user. The `targetId` is the user key of
+      the target user.
     value: 0
     tags: []
     deprecation_message: ''
   - name: Universe
-    summary: ''
+    summary: |
+      The target is a universe. The `targetId` is the universe ID as a string.
     value: 1
     tags: []
     deprecation_message: ''
   - name: CustomTag
-    summary: ''
+    summary: |
+      The target is a custom content tag. The `targetId` is the tag string.
     value: 2
     tags: []
     deprecation_message: ''

--- a/content/en-us/reference/engine/enums/RecommendationPreferenceType.yaml
+++ b/content/en-us/reference/engine/enums/RecommendationPreferenceType.yaml
@@ -4,29 +4,35 @@
 
 name: RecommendationPreferenceType
 type: enum
-summary: ''
+summary: |
+  The type of preference signal logged via
+  `Class.RecommendationService.LogPreferenceEvent|LogPreferenceEvent`.
 description: ''
 code_samples: []
 tags: []
 deprecation_message: ''
 items:
   - name: AddFollow
-    summary: ''
+    summary: |
+      The user started following the target.
     value: 0
     tags: []
     deprecation_message: ''
   - name: RemoveFollow
-    summary: ''
+    summary: |
+      The user stopped following the target.
     value: 1
     tags: []
     deprecation_message: ''
   - name: AddMute
-    summary: ''
+    summary: |
+      The user muted the target.
     value: 2
     tags: []
     deprecation_message: ''
   - name: RemoveMute
-    summary: ''
+    summary: |
+      The user unmuted a previously muted target.
     value: 3
     tags: []
     deprecation_message: ''


### PR DESCRIPTION
Fills in the auto-generated skeletons for `RecommendationService:LogPreferenceEvent` and its two associated enums with descriptions, per-parameter summaries, and enum-value summaries, matching the style of the sibling `LogImpressionEvent` and `LogActionEvent` entries.

## Files changed

- `content/en-us/reference/engine/classes/RecommendationService.yaml` — fills the empty `LogPreferenceEvent` method skeleton (description, per-parameter summaries, `code_samples: [LogPreferenceEvent-example]`).
- `content/en-us/reference/engine/enums/RecommendationPreferenceType.yaml` — fills top-level summary and per-item summaries (`AddFollow`, `RemoveFollow`, `AddMute`, `RemoveMute`).
- `content/en-us/reference/engine/enums/RecommendationPreferenceTargetType.yaml` — fills top-level summary and per-item summaries (`User`, `Universe`, `CustomTag`), including how `targetId` should be interpreted per variant.

## Verification

- Signature (parameter names, order, types, defaults) and capability (`Basic`) verified against the engine bindings.
- Enum values verified against the engine enum definitions (`AddFollow`=0, `RemoveFollow`=1, `AddMute`=2, `RemoveMute`=3; `User`=0, `Universe`=1, `CustomTag`=2).
- All three YAML files parse cleanly and the new method entry has key parity with the sibling `LogActionEvent` entry.
