### PR TITLE
Add guidance about wildcard usage for groupId for endpoint Cloud_ListGroupMemberships

### DIFF
--- a/content/en-us/reference/cloud/cloud.docs.json
+++ b/content/en-us/reference/cloud/cloud.docs.json
@@ -729,7 +729,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID, supports wildcard \"-\" when filtering: https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships",
+            "description": "The group ID, supports wildcard \"-\" when [filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
             "required": true,
             "schema": {
               "type": "string"

--- a/content/en-us/reference/cloud/cloud.docs.json
+++ b/content/en-us/reference/cloud/cloud.docs.json
@@ -729,7 +729,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID.",
+            "description": "The group ID, supports wildcard \"-\" when filtering: https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships",
             "required": true,
             "schema": {
               "type": "string"

--- a/content/en-us/reference/cloud/cloud.docs.json
+++ b/content/en-us/reference/cloud/cloud.docs.json
@@ -729,7 +729,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID.\n\nSupports wildcard ``-`` when\n[filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
+            "description": "The group ID.\n\nSupports wildcard ``-`` when\n[filtering](/cloud/reference/patterns#list-group-memberships)",
             "required": true,
             "schema": {
               "type": "string"

--- a/content/en-us/reference/cloud/cloud.docs.json
+++ b/content/en-us/reference/cloud/cloud.docs.json
@@ -729,7 +729,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID, supports wildcard \"-\" when [filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
+            "description": "The group ID.\n\nSupports wildcard ``-`` when\n[filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
             "required": true,
             "schema": {
               "type": "string"

--- a/content/en-us/reference/cloud/openapi.json
+++ b/content/en-us/reference/cloud/openapi.json
@@ -2329,7 +2329,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID.",
+            "description": "The group ID, supports wildcard \"-\" when filtering: https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships",
             "required": true,
             "schema": {
               "type": "string"

--- a/content/en-us/reference/cloud/openapi.json
+++ b/content/en-us/reference/cloud/openapi.json
@@ -2329,7 +2329,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID, supports wildcard \"-\" when filtering: https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships",
+            "description": "The group ID, supports wildcard \"-\" when [filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
             "required": true,
             "schema": {
               "type": "string"

--- a/content/en-us/reference/cloud/openapi.json
+++ b/content/en-us/reference/cloud/openapi.json
@@ -2329,7 +2329,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID, supports wildcard \"-\" when [filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
+            "description": "The group ID.\n\nSupports wildcard ``-`` when\n[filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
             "required": true,
             "schema": {
               "type": "string"

--- a/content/en-us/reference/cloud/openapi.json
+++ b/content/en-us/reference/cloud/openapi.json
@@ -2329,7 +2329,7 @@
           {
             "name": "group_id",
             "in": "path",
-            "description": "The group ID.\n\nSupports wildcard ``-`` when\n[filtering](https://create.roblox.com/docs/cloud/reference/patterns#list-group-memberships)",
+            "description": "The group ID.\n\nSupports wildcard ``-`` when\n[filtering](/cloud/reference/patterns#list-group-memberships)",
             "required": true,
             "schema": {
               "type": "string"


### PR DESCRIPTION
## Changes

I found the API documentation to be confusing. I was originally trying to determine whether or not I could get all of a users group memberships for [ReAdmin](https://readmin.app), and noticed there was not an obvious/clear endpoint to do this. Treeben77 called out that there is the ability to use ``-`` as a wildcard on the Cloud_ListGroupMemberships endpoint, and to use "filter" to get all groups a user(s) are in. This change adds this documentation to the group ID param.

[Devforum Feature Request](https://devforum.roblox.com/t/replacement-for-groupsrobloxcomv2usersuseridgroupsroles/4651939/2)

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
