### PR TITLE
Update old highlight slot limit still present in warning

### DIFF
--- a/content/en-us/effects/highlighting.md
+++ b/content/en-us/effects/highlighting.md
@@ -144,7 +144,7 @@ The `Class.Highlight.DepthMode|DepthMode` property controls how the effect displ
 The `Class.Highlight.Enabled|Enabled` property allows you to quickly enable or disable the highlight **without any impact on performance**.
 
 <Alert severity="warning">
-While a disabled `Class.Highlight` doesn't display, it still takes one of the 31 available `Class.Highlight` slots. If you plan to permanently disable a `Class.Highlight` instance, it's best to delete the highlight rather than disable it.
+While a disabled `Class.Highlight` doesn't display, it still takes one of the 255 available `Class.Highlight` slots. If you plan to permanently disable a `Class.Highlight` instance, it's best to delete the highlight rather than disable it.
 </Alert>
 
 ## Performance tips


### PR DESCRIPTION
## Changes

While #1483 did update the limit, another instance of the old limit — in the warning for disabled highlights — was kept intact. This PR updates that number to the correct value.

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
