### PR TITLE
Fix variable name typo in Scripting page Luau basics example

### DIFF
--- a/content/en-us/scripting/index.md
+++ b/content/en-us/scripting/index.md
@@ -45,7 +45,7 @@ Luau uses `nil` to represent nonexistence or nothingness, which evaluates as `fa
 ```lua
 local messageToUser
 print(messageToUser) --> nil
-print(type(message)) --> nil
+print(type(messageToUser)) --> nil
 if messageToUser then
 	-- statement evaluates to false
 end


### PR DESCRIPTION
## Changes

In the "Luau basics" section of the Scripting page, the `nil` example calls `type(message)`, but the declared variable is `messageToUser`:

```lua
local messageToUser
print(messageToUser) --> nil
print(type(message)) --> nil   -- references undeclared `message`
```

`message` is an undeclared global (also `nil`), so the printed output is coincidentally correct, but the reference is meant to be the local variable (I assume).

**Fix:** `type(message)` → `type(messageToUser)`
**File:** `content/en-us/scripting/index.md`

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.