### PR TITLE
Clarify rewarded video availability check timing

### DIFF
--- a/content/en-us/production/promotion/rewarded-video-ads.md
+++ b/content/en-us/production/promotion/rewarded-video-ads.md
@@ -65,7 +65,7 @@ To set up a rewarded video ad inside your game:
 To implement the rewarded video ad on the client-side:
 
 1. Add a new `Class.LocalScript` to the button you just inserted into your game.
-2. Use the `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` method to make sure the button is only visible to the user if an ad is available.
+2. Use `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` to check whether an ad is available before attempting to show it.
 
 <Alert severity="warning">
   Call `GetAdAvailabilityNowAsync` as close as possible to the moment you plan to show the ad. For example, if you have a "Watch video ad to get a reward" button in a shop menu, only call it when the user opens the shop menu.

--- a/content/en-us/production/promotion/rewarded-video-ads.md
+++ b/content/en-us/production/promotion/rewarded-video-ads.md
@@ -67,10 +67,6 @@ To implement the rewarded video ad on the client-side:
 1. Add a new `Class.LocalScript` to the button you just inserted into your game.
 2. Use the `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` method to make sure the button is only visible to the user if an ad is available.
 
-<Alert severity="warning">
-  When possible, call `GetAdAvailabilityNowAsync` only after the user takes a clear action to watch the ad, such as clicking the video ad play button. Maximizing the ratio of impressions to filled requests can benefit fill rate, EPM, and earnings.
-</Alert>
-
 ```lua title="Code example for rewarded video ad (Client)"
 -- Services
 local AdService = game:GetService("AdService")
@@ -373,7 +369,7 @@ To prevent abuse of the rewarded ad system and to provide the best user experien
 
 To get the most out of your rewarded video ad, make sure to:
 
-- When possible, call `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` only after the user takes a clear action to watch the ad, such as clicking the video ad play button.
+- Call `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` as close as possible to the moment you plan to show the ad. For example, if you have a "Watch video ad to get a reward" button in a shop menu, you should only call `GetAdAvailabilityNowAsync` when the user opens the shop menu. This approach improves performance by preventing ads from unnecessarily being held in memory, and benefits CPM (cost-per-thousand impressions) and earnings by optimizing the ad fill rate.
 - After an ad finishes, only call `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` if you offer the user another ad to watch.
 - Use analytics to identify the best placement for video ads to encourage user engagement without disrupting gameplay.
 - Use ad opportunities to track when you offer a user a chance to watch a video ad for a reward. Keep an eye on the ratio between filled requests, ad opportunities, and ad impressions to figure out if you should make your ads easier to find or if your rewards need to be more compelling.

--- a/content/en-us/production/promotion/rewarded-video-ads.md
+++ b/content/en-us/production/promotion/rewarded-video-ads.md
@@ -67,6 +67,10 @@ To implement the rewarded video ad on the client-side:
 1. Add a new `Class.LocalScript` to the button you just inserted into your game.
 2. Use the `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` method to make sure the button is only visible to the user if an ad is available.
 
+<Alert severity="warning">
+  When possible, call `GetAdAvailabilityNowAsync` only after the user takes a clear action to watch the ad, such as clicking the video ad play button. Maximizing the ratio of impressions to filled requests can benefit fill rate, EPM, and earnings.
+</Alert>
+
 ```lua title="Code example for rewarded video ad (Client)"
 -- Services
 local AdService = game:GetService("AdService")
@@ -369,8 +373,8 @@ To prevent abuse of the rewarded ad system and to provide the best user experien
 
 To get the most out of your rewarded video ad, make sure to:
 
-- Call `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` as close as possible to the moment you plan to show the ad. For example, if you have a "Watch video ad to get a reward" button in a shop menu, you should only call `GetAdAvailabilityNowAsync` when the user opens the shop menu. This approach improves performance by preventing ads from unnecessarily being held in memory, and benefits CPM (cost-per-thousand impressions) and earnings by optimizing the ad fill rate.
-- Call `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` when the user finishes watching the ad to determine if another ad is available for the user to watch.
+- When possible, call `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` only after the user takes a clear action to watch the ad, such as clicking the video ad play button.
+- After an ad finishes, only call `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` if you offer the user another ad to watch.
 - Use analytics to identify the best placement for video ads to encourage user engagement without disrupting gameplay.
 - Use ad opportunities to track when you offer a user a chance to watch a video ad for a reward. Keep an eye on the ratio between filled requests, ad opportunities, and ad impressions to figure out if you should make your ads easier to find or if your rewards need to be more compelling.
 

--- a/content/en-us/production/promotion/rewarded-video-ads.md
+++ b/content/en-us/production/promotion/rewarded-video-ads.md
@@ -67,6 +67,10 @@ To implement the rewarded video ad on the client-side:
 1. Add a new `Class.LocalScript` to the button you just inserted into your game.
 2. Use the `Class.AdService.GetAdAvailabilityNowAsync|GetAdAvailabilityNowAsync` method to make sure the button is only visible to the user if an ad is available.
 
+<Alert severity="warning">
+  Call `GetAdAvailabilityNowAsync` as close as possible to the moment you plan to show the ad. For example, if you have a "Watch video ad to get a reward" button in a shop menu, only call it when the user opens the shop menu.
+</Alert>
+
 ```lua title="Code example for rewarded video ad (Client)"
 -- Services
 local AdService = game:GetService("AdService")


### PR DESCRIPTION
## Changes

This surfaces the existing `GetAdAvailabilityNowAsync` timing guidance next to the client implementation steps. Developers should call the method as close as possible to showing the ad, such as when the user opens the shop menu containing the video ad button.

The best practices now also avoid calling `GetAdAvailabilityNowAsync` after an ad finishes unless another ad is being offered.

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.