### PR TITLE
Clarify metatable usage and weak tables

### DIFF
--- a/content/en-us/luau/metatables.md
+++ b/content/en-us/luau/metatables.md
@@ -111,7 +111,7 @@ Here's the list of available metamethods:
 		</tr>
 	  <tr>
 		  <td>`__mode`</td>
-		  <td>Used in weak tables, declaring whether the keys and/or values of a table are weak. Note that references to Roblox instances are never weak. Tables that hold such references will never be garbage collected.</td>
+		  <td>Used in weak tables, declaring whether the keys and/or values of a table are weak.</td>
 		</tr>
 	  <tr>
 		  <td>`__len(table)`</td>
@@ -177,7 +177,11 @@ print(a / 2) -- 5, 2.5
 
 ### Usage
 
-There are many ways to use metatables, for example the `__unm` metamethod to make a table negative:
+There are many ways to use metatables
+
+#### Apply the unary minus operator to tables
+
+For example the `__unm` metamethod to make a table negative:
 
 ```lua
 local metatable = {
@@ -193,6 +197,8 @@ local metatable = {
 local table1 = setmetatable({10, 11, 12}, metatable)
 print(table.concat(-table1, "; ")) --> -10; -11; -12
 ```
+
+#### Index missing values from another table
 
 Here's an interesting way to declare things using `__index`:
 
@@ -215,6 +221,8 @@ local t = {10, 20, 30}
 print(t(5))
 ```
 
+#### Call a table like a function
+
 Typically you can't call a table, but with metatables you can:
 
 ```lua
@@ -231,6 +239,8 @@ local metatable = {
 local t = setmetatable({10, 20, 30}, metatable)
 print(t(5)) --> 15 25 35
 ```
+
+#### Apply the addition operator to tables
 
 You can do a lot more as well, such as adding tables:
 
@@ -272,6 +282,8 @@ for k, v in table1 + table2 do
 end
 ```
 
+#### Create a caching table
+
 When playing with metatables, you may run into some problems. If you need to use the `__index` metamethod to create new values in a table, but that table's metatable also has a `__newindex` metamethod, you'll want to use the Luau built-in function `Global.LuaGlobals.rawset()` to set the value without invoking any metamethods. Take the following code as an example of what happens if you don't use these functions.
 
 ```lua
@@ -301,6 +313,62 @@ local t = setmetatable({}, {
 })
 print(t[1]) --> 10
 ```
+
+#### Create weak tables
+
+Variables that contain tables, functions, userdata, and `Class.Instance|Instances` store references to those objects instead of copying them. Assigning an object to another variable creates another reference to the same object:
+
+```lua
+local map = {key = 1}
+local mapReference = map
+print(map == mapReference) --> true
+print(map == {key = 1}) --> false
+
+local function func() end
+local funcReference = func
+print(func == funcReference) --> true
+
+local part = Instance.new("Part")
+local partReference = part
+print(part == partReference) --> true
+```
+
+Objects that are no longer reachable through strong references become eligible for garbage collection. Setting one variable to `nil` doesn't make an object eligible for garbage collection if another strong reference still points to that object:
+
+```lua
+local child = {}
+local parent = {Child = child}
+child = nil
+
+print(parent.Child) --> table: [hexadecimal memory address]
+```
+
+Although `child` no longer refers to the child table, `parent.Child` still does. As long as the parent table remains reachable, its reference keeps the child table reachable as well.
+
+A **weak table** holds keys, values, or both without preventing the garbage collector from reclaiming otherwise unreachable objects. Set the `__mode` field of the table's metatable to control which references are weak:
+
+- `k` makes the keys weak.
+- `v` makes the values weak.
+- `kv` makes both the keys and values weak.
+
+The following code sample creates a table with weak values:
+
+```lua
+local children = setmetatable({}, {
+	__mode = "v",
+})
+
+do
+	local child = {}
+	children.example = child
+end
+```
+
+After the `do` block ends, the value stored in `children.example` has no strong references and becomes eligible for garbage collection. When the garbage collector reclaims the child table, Luau removes its entry from `children`. Garbage collection is nondeterministic, so don't depend on when the entry disappears.
+
+<Alert severity="warning">
+Don't use weak tables to track whether an `Class.Instance` exists in the data model. Use `Class.Instance.AncestryChanged` to observe hierarchy changes, or `Class.CollectionService:GetInstanceRemovedSignal()` to observe when a tagged instance loses its tag or leaves the data model. Even if an instance is still retained by the engine, its Luau-side reference can be garbage-collected when no strong Luau references to it remain.
+</Alert>
 
 ## Use the set datatype
 


### PR DESCRIPTION
## Changes

* Reorganized the use cases for metatables under clearer headings.
* Removed the ambiguous explanation of weak metatable behavior.
  The statement that "references to Roblox instances are never weak" could easily be misinterpreted to mean that references remain strong even inside weak tables. Likewise, readers might incorrectly assume that setting `__mode` causes an Instance to be collected automatically even when it is still alive in the game engine.
* Added use cases for weak metatables.
* Added a warning explaining that, when weakly referencing an Instance, the removal of all Luau references does not necessarily mean that the corresponding reference has also been released in the underlying C++ environment.

These behaviors have frequently been misunderstood. Many developers have assumed that an Instance stored in a weak table is collected only after the Instance itself has actually been destroyed.

As a result, some have also incorrectly reported the expected behavior as a bug when the Instance was not collected under those assumptions.

These sections should be clarified to prevent further confusion.

Related discussions:

* https://devforum.roblox.com/t/weak-tables-dont-work-with-instances/86634?u=sakura_soyuta
* https://devforum.roblox.com/t/studio-beta-reference-instances-directly-with-attributes/4753441/48?u=sakura_soyuta


## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
