### PR TITLE
docs: add Advertising API guide + scope sponsor-items to items

### DIFF
--- a/content/en-us/cloud/guides/advertising/concepts.md
+++ b/content/en-us/cloud/guides/advertising/concepts.md
@@ -1,0 +1,35 @@
+---
+title: Advertising concepts
+description: Key concepts for the Advertising API - campaign status versus delivery status, micro-USD money, objectives, creatives, and versioning.
+---
+
+Read these concepts before using the [Advertising API](index.md).
+
+## Status versus delivery status
+
+Every campaign carries two independent fields:
+
+- **`status`** — the lifecycle state you control through update requests: `ACTIVE`, `PAUSED`, or `CANCELLED`. `CANCELLED` is permanent.
+- **`deliveryStatus`** — the serving state the system derives (read-only): `IN_REVIEW`, `SERVING`, `NOT_SERVING`, or `REJECTED`.
+
+A newly created campaign is `ACTIVE` / `IN_REVIEW` until ad-policy review completes. Use `status` for lifecycle actions and `deliveryStatus` to answer "is it serving?" When a campaign is `NOT_SERVING` or `REJECTED`, `deliveryStatusReasons` explains why.
+
+## Money is micro-USD strings
+
+Budget amounts are expressed in **micro-USD as decimal strings** — `"5000000"` equals $5.00. Money is sent and returned as a string so large values keep full precision in every client. Convert to dollars by dividing by 1,000,000.
+
+## Objective
+
+Only the `ENGAGEMENT` objective (drive visits to your experience) is available in v1.
+
+## Creatives
+
+Creatives are Open Cloud **image assets**. Upload an image with the [Assets API](../../features/assets.md), then reference its asset ID in `creativeAssetIds` when creating a campaign. The assets must already exist and be usable by the caller; they are validated and saved to the account's reusable creatives when the campaign is created.
+
+## Budget changes
+
+A budget **increase** applies immediately. A **decrease** on a running campaign is applied at the next midnight in the billing account's time zone; until then the campaign keeps serving on the current (higher) amount. A pending decrease is surfaced as `scheduledAmountMicros` and `scheduledEffectiveTime` on the budget.
+
+## Versioning
+
+The major version is in the path (`/ads-management/v1`). Additive, backward-compatible changes are delivered as minor versions selected with the `X-Roblox-Api-Version` header; the frozen `1.0` baseline is the default, so you opt in to newer minors explicitly.

--- a/content/en-us/cloud/guides/advertising/concepts.md
+++ b/content/en-us/cloud/guides/advertising/concepts.md
@@ -24,7 +24,7 @@ Only the `ENGAGEMENT` objective (drive visits to your experience) is available i
 
 ## Creatives
 
-Creatives are Open Cloud **image assets**. Upload an image with the [Assets API](../../features/assets.md), then reference its asset ID in `creativeAssetIds` when creating a campaign. The assets must already exist and be usable by the caller; they are validated and saved to the account's reusable creatives when the campaign is created.
+Creatives are Open Cloud **image assets**. Upload an image with the [Assets API](../usage-assets.md), then reference its asset ID in `creativeAssetIds` when creating a campaign. The assets must already exist and be usable by the caller; they are validated and saved to the account's reusable creatives when the campaign is created.
 
 ## Budget changes
 

--- a/content/en-us/cloud/guides/advertising/index.md
+++ b/content/en-us/cloud/guides/advertising/index.md
@@ -1,0 +1,124 @@
+---
+title: Advertising
+description: Use Open Cloud to create and manage advertising campaigns that drive engagement to your experiences.
+---
+
+The Advertising API lets you programmatically create and manage advertising campaigns that drive players to your experiences. This API supports:
+
+- Creating engagement campaigns that promote an experience across Roblox ad surfaces.
+- Managing the campaign lifecycle: pause, resume, adjust budget, and cancel.
+- Monitoring the review and serving state of a campaign as it is approved and delivered.
+
+<Alert severity="info">
+This API advertises **experiences**. To sponsor **Marketplace items or assets**, see [Sponsored campaigns](/docs/cloud/reference/features/sponsored-campaigns).
+</Alert>
+
+Before using this API, [generate an API key](../../auth/api-keys.md) and grant it the advertising operations `ad.campaign:read`, `ad.campaign:write`, and `ad.billing:read`. Include the key in the `x-api-key` request header on every request. All endpoints are served from `https://apis.roblox.com/ads-management/v1`.
+
+Campaigns carry two independent states (a lifecycle `status` and a derived `deliveryStatus`), use micro-USD money, and expose a single objective in v1. Read [Advertising concepts](concepts.md) before you start.
+
+## Find an experience to advertise
+
+List the experiences the account can advertise, then fetch the valid campaign options (objectives, payment types, ad formats, and targeting dimensions) for the one you choose.
+
+```bash title="List advertisable experiences"
+curl --location 'https://apis.roblox.com/ads-management/v1/advertisable-universes' \
+--header 'x-api-key: ${ApiKey}'
+```
+
+```bash title="Get campaign options"
+curl --location 'https://apis.roblox.com/ads-management/v1/campaign-options?universeId=${UniverseId}' \
+--header 'x-api-key: ${ApiKey}'
+```
+
+The response confirms whether the experience is eligible and returns the values you can use when creating a campaign.
+
+## Prepare a creative
+
+Campaigns advertise Open Cloud **image assets**. Upload your image with the [Assets API](../../features/assets.md), then reference the returned asset ID in `creativeAssetIds`. To list creatives already in the account's library:
+
+```bash title="List creatives"
+curl --location 'https://apis.roblox.com/ads-management/v1/creatives' \
+--header 'x-api-key: ${ApiKey}'
+```
+
+## Create a campaign
+
+Send a `POST` to `/campaigns` with the experience, creative asset IDs, budget, and schedule. The `x-idempotency-key` header is required and must be a UUID; replaying the same key with an identical body within 24 hours returns the original campaign.
+
+```bash title="Create an engagement campaign"
+curl --location 'https://apis.roblox.com/ads-management/v1/campaigns' \
+--header 'x-api-key: ${ApiKey}' \
+--header 'x-idempotency-key: ${UUID}' \
+--header 'Content-Type: application/json' \
+--data '{
+    "name": "Summer promo",
+    "objective": "ENGAGEMENT",
+    "paymentType": "CREDIT_CARD",
+    "targetUniverseId": "${UniverseId}",
+    "creativeAssetIds": ["${AssetId}"],
+    "budget": { "type": "DAILY", "amountMicros": "5000000" },
+    "schedule": { "startTime": "2026-08-01T00:00:00Z", "durationInDays": 7 }
+}'
+```
+
+`budget.amountMicros` is micro-USD as a decimal string (`"5000000"` = $5.00). On success the campaign is returned with `deliveryStatus` `IN_REVIEW` — it is queued for ad-policy review and is not yet serving:
+
+```json title="Response (200 OK)"
+{
+  "id": "1122334455",
+  "name": "Summer promo",
+  "objective": "ENGAGEMENT",
+  "paymentType": "CREDIT_CARD",
+  "targetUniverseId": "1234567890",
+  "creativeAssetIds": ["9876543210"],
+  "budget": { "type": "DAILY", "amountMicros": "5000000" },
+  "schedule": { "startTime": "2026-08-01T00:00:00Z", "durationInDays": 7 },
+  "status": "ACTIVE",
+  "deliveryStatus": "IN_REVIEW",
+  "createTime": "2026-07-27T00:00:00Z",
+  "updateTime": "2026-07-27T00:00:00Z"
+}
+```
+
+## Check whether a campaign is serving
+
+Poll delivery status until it settles (`SERVING`, `NOT_SERVING`, or `REJECTED`). Look up as many as 100 campaigns per call:
+
+```bash title="Batch get campaign status"
+curl --location 'https://apis.roblox.com/ads-management/v1/campaigns:batchGetStatus' \
+--header 'x-api-key: ${ApiKey}' \
+--header 'Content-Type: application/json' \
+--data '{ "campaignIds": ["1122334455"] }'
+```
+
+```json title="Response (200 OK)"
+{
+  "statuses": [
+    {
+      "id": "1122334455",
+      "status": "ACTIVE",
+      "deliveryStatus": "SERVING"
+    }
+  ]
+}
+```
+
+When `deliveryStatus` is `NOT_SERVING` or `REJECTED`, read `deliveryStatusReasons` for the actionable detail.
+
+## Manage a campaign
+
+Use `PATCH /campaigns/{id}` to pause, resume, rename, or change the budget. Only send the fields you are changing.
+
+```bash title="Pause a campaign"
+curl --location --request PATCH 'https://apis.roblox.com/ads-management/v1/campaigns/1122334455' \
+--header 'x-api-key: ${ApiKey}' \
+--header 'Content-Type: application/json' \
+--data '{ "status": "PAUSED" }'
+```
+
+Resume with `"status": "ACTIVE"`; cancel (permanent) with `"status": "CANCELLED"`. A budget increase applies immediately; a decrease on a running campaign takes effect at the next midnight in the account's time zone.
+
+## Report on performance
+
+Campaign performance reporting is moving to the [Analytics API](../analytics/index.md), which will support filtering metrics by campaign. Use the Analytics API for spend, impressions, and other performance metrics.

--- a/content/en-us/cloud/guides/advertising/index.md
+++ b/content/en-us/cloud/guides/advertising/index.md
@@ -35,7 +35,7 @@ The response confirms whether the experience is eligible and returns the values 
 
 ## Prepare a creative
 
-Campaigns advertise Open Cloud **image assets**. Upload your image with the [Assets API](../../features/assets.md), then reference the returned asset ID in `creativeAssetIds`. To list creatives already in the account's library:
+Campaigns advertise Open Cloud **image assets**. Upload your image with the [Assets API](../usage-assets.md), then reference the returned asset ID in `creativeAssetIds`. To list creatives already in the account's library:
 
 ```bash title="List creatives"
 curl --location 'https://apis.roblox.com/ads-management/v1/creatives' \

--- a/content/en-us/marketplace/sponsor-items.md
+++ b/content/en-us/marketplace/sponsor-items.md
@@ -9,7 +9,7 @@ Sponsor items to increase the discoverability of your 3D user-generated content 
 <img src="../assets/promotion/misc/Sponsored-Items.png" width="846" />
 
 <Alert severity="info">
-This article covers sponsoring **Marketplace items**. To advertise an **experience**, use Ads Manager or the [Advertising API](../cloud/guides/advertising/index.md) instead.
+This article covers sponsoring **Marketplace items**. To advertise an **experience**, use [Ads Manager](../production/promotion/ads-manager.md) or the [Advertising API](../cloud/guides/advertising/index.md) instead.
 </Alert>
 
 ## Bidding system

--- a/content/en-us/marketplace/sponsor-items.md
+++ b/content/en-us/marketplace/sponsor-items.md
@@ -8,6 +8,10 @@ Sponsor items to increase the discoverability of your 3D user-generated content 
 
 <img src="../assets/promotion/misc/Sponsored-Items.png" width="846" />
 
+<Alert severity="info">
+This article covers sponsoring **Marketplace items**. To advertise an **experience**, use Ads Manager or the [Advertising API](../cloud/guides/advertising/index.md) instead.
+</Alert>
+
 ## Bidding system
 
 Advertisement space works on a bidding system where the higher you set your **Daily Budget** amount in relation to other creators' bids, the more likely your sponsored item will display within the **Sponsored** category on any item's details page on the Roblox website or in the Roblox app. The location of each sponsored item within the category is random.


### PR DESCRIPTION
## What

Documents the new **Advertising** (Ads Manager) Open Cloud API and clarifies where experience vs. item advertising lives.

### New guide: `content/en-us/cloud/guides/advertising/`
- `index.md` — task walkthrough: auth/scopes → find an advertisable experience → prepare a creative (Assets API) → create a campaign → poll delivery status → manage (pause/resume/budget) → reporting via the Analytics API. Modeled on the Analytics guide.
- `concepts.md` — status vs. deliveryStatus, micro-USD money, the ENGAGEMENT objective, creatives, budget-change timing, and versioning.

### Edit: `content/en-us/marketplace/sponsor-items.md`
Adds a scope note clarifying the page is about **Marketplace items**, and points **experience** advertising to Ads Manager / the Advertising API. No other content changed.

## Why
Experience campaigns now run through Ads Manager and its public API (`apis.roblox.com/ads-management/v1`); item campaigns remain the Marketplace sponsored-items flow. The docs didn't surface the new API or draw that line clearly.

## Related
- Feature/reference grouping + Sponsored campaigns pointer: `open-cloud-contracts` PR (adds `docs/features/advertising.yaml`; edits `sponsored-campaigns.yaml`). This guide is what that feature description links to.
- Performance endpoints are intentionally omitted (moving to the Analytics API with campaign filtering).

## Notes for reviewers
- API-key scope names (`ad.campaign:read/write`, `ad.billing:read`) come from the gateway config; please confirm the exact API-key UI wording.
- Draft — the linked feature reference page goes live once the `open-cloud-contracts` change is synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
