### PR TITLE
Remove incorrect units on DataStore Storage Description

### DIFF
--- a/content/en-us/cloud-services/extended-services.md
+++ b/content/en-us/cloud-services/extended-services.md
@@ -183,7 +183,7 @@ See the following table for Extended Services pricing:
   <tr>
     <td><a href="https://create.roblox.com/docs/cloud-services/data-stores" style={{color: 'inherit', textDecoration: 'underline'}}>Data store storage </a></td>
     <td>Storage</td>
-    <td>100 MB + (1MB * Lifetime Players)</td>
+    <td>100 MB + (1 MB * Lifetime Players)</td>
     <td>$0.12 / GB per month</td>
   </tr>
 

--- a/content/en-us/cloud-services/extended-services.md
+++ b/content/en-us/cloud-services/extended-services.md
@@ -183,7 +183,7 @@ See the following table for Extended Services pricing:
   <tr>
     <td><a href="https://create.roblox.com/docs/cloud-services/data-stores" style={{color: 'inherit', textDecoration: 'underline'}}>Data store storage </a></td>
     <td>Storage</td>
-    <td>100 MB + (1 MB * Lifetime Players)</td>
+    <td>100 MB + (1 MB * Lifetime Players) GB per month</td>
     <td>$0.12 / GB per month</td>
   </tr>
 

--- a/content/en-us/cloud-services/extended-services.md
+++ b/content/en-us/cloud-services/extended-services.md
@@ -183,7 +183,7 @@ See the following table for Extended Services pricing:
   <tr>
     <td><a href="https://create.roblox.com/docs/cloud-services/data-stores" style={{color: 'inherit', textDecoration: 'underline'}}>Data store storage </a></td>
     <td>Storage</td>
-    <td>100 MB + (1MB * Lifetime Players) GB per month</td>
+    <td>100 MB + (1MB * Lifetime Players)</td>
     <td>$0.12 / GB per month</td>
   </tr>
 


### PR DESCRIPTION
The formula already contains the storage unit (MB) and the timeframe (lifetime), so the GB per month is inaccurate and unnecessary.

## Changes

<!-- Please summarize your changes. -->
I removed an extra set of units on the Data store storage description.
<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
