### PR TITLE
Fix "game" rebranding typo

### DIFF
--- a/content/en-us/production/experiments.md
+++ b/content/en-us/production/experiments.md
@@ -212,7 +212,7 @@ For convenience, the results page lets you replace the default config value with
 
 - **Don't act without statistical significance.** Even seemingly large changes in player behavior might not be statistically significant, generally due to small sample size. If a change isn't statistically significant, ignore it.
 
-- **Avoid changes during experiments**. Major bugs of course need fixes, but changes to experiegamence content can impact player behavior and invalidate your results, even if the changes **seem** unrelated to your experiment. Similarly, only run experiments simultaneously if you're confident they won't interact with each other.
+- **Avoid changes during experiments**. Major bugs of course need fixes, but changes to game content can impact player behavior and invalidate your results, even if the changes **seem** unrelated to your experiment. Similarly, only run experiments simultaneously if you're confident they won't interact with each other.
 
 - **Use confidence intervals for deep dives** into metrics and to check for borderline cases of statistical significance. If the confidence interval is too wide, the metric might never reach statistical significance.
 


### PR DESCRIPTION
## Changes

In a previous commit, all references of "experiences" were corrected to "games" by the Roblox team. Seemingly, when changing them, a mistake was made during the chance that lead to an (arguably quite funny) typo of "experiegamence". This simply fixes that.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [x] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [x] To the best of my knowledge, all proposed changes are accurate.
