### PR TITLE
Optimize link line-number tracking with a forward-only scan

### DIFF
--- a/tools/checks/utils/links.test.ts
+++ b/tools/checks/utils/links.test.ts
@@ -87,6 +87,30 @@ describe('isRobloxUrl', () => {
 });
 
 describe('getLinksOfTypeFromContentString', () => {
+  test.each([LinkType.Page, LinkType.Asset])(
+    'tracks line numbers across consecutive calls for link type %p',
+    (linkType) => {
+      const link =
+        linkType === LinkType.Page ? '[link](a.md)' : '![image](a.png)';
+      const ref = linkType === LinkType.Page ? 'a.md' : 'a.png';
+      for (const newline of ['\n', '\r\n']) {
+        const text = [link + link, '', link, link].join(newline);
+        for (const suffix of ['', newline]) {
+          expect(
+            getLinksOfTypeFromContentString(text + suffix, linkType)
+          ).toEqual([1, 1, 3, 4].map((lineNumber) => ({ ref, lineNumber })));
+        }
+      }
+      expect(getLinksOfTypeFromContentString(link, linkType)).toEqual([
+        { ref, lineNumber: 1 },
+      ]);
+      expect(getLinksOfTypeFromContentString('', linkType)).toEqual([]);
+      expect(
+        getLinksOfTypeFromContentString('No links\n here', linkType)
+      ).toEqual([]);
+    }
+  );
+
   const fileText = `---
 title: Great Title
 description: One sentence description of the page.

--- a/tools/checks/utils/links.ts
+++ b/tools/checks/utils/links.ts
@@ -105,33 +105,16 @@ export const getLinksOfTypeFromContentString = (
   text: string,
   linkType: LinkType
 ): LinkInfo[] => {
-  // Initialize an array to store the starting index of each line
-  // Line 1 starts at index 0
-  const newLineIndexes: number[] = [0];
   let lineNumber = 1;
-
-  // Loop through the text to find each newline character
-  // When you find a newline, store the starting index of the next line
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === '\n') {
-      newLineIndexes[lineNumber] = i + 1;
-      lineNumber++;
-    }
-  }
+  let nextNewline = text.indexOf('\n');
 
   const regex =
     linkType === LinkType.Asset ? ASSET_LINK_REGEX : PAGE_LINK_REGEX;
-  const matches = Array.from(text.matchAll(regex));
-
-  // Map through each match to create an array of LinkInfo objects
-  // For each match, find its line number and populate the object accordingly
-  const links: LinkInfo[] = matches.map((match) => {
-    // -1 represents "not found"
-    const index = match.index ?? -1;
-    let lineNumber = -1;
-    if (index !== -1) {
-      // Find the line number where the index of the match exists
-      lineNumber = newLineIndexes.findIndex((startIdx) => startIdx > index);
+  // Matches arrive in document order, so each newline only needs one visit.
+  const links: LinkInfo[] = Array.from(text.matchAll(regex), (match) => {
+    while (nextNewline !== -1 && nextNewline < match.index!) {
+      lineNumber++;
+      nextNewline = text.indexOf('\n', nextNewline + 1);
     }
     return {
       ref: match[1] || match[2] || match[3],


### PR DESCRIPTION
## Changes

`getLinksOfTypeFromContentString` currently searches the line-offset array from the beginning for every link. Track newlines with a forward-only cursor instead, since `matchAll` returns matches in document order. This reduces line-number bookkeeping from O(characters + links × lines) to O(characters + links), removes the line-offset array, and avoids an intermediate array of regex matches.

Links on the final line without a trailing newline now receive their actual 1-based line number instead of `-1`. Link matching and reference extraction are unchanged.

Added regression coverage for page and asset links, multiple links on a line, blank lines, LF/CRLF, final lines with and without a newline, empty/link-free input, and consecutive calls.

## Validation

- All 13 Jest suites / 372 tests pass on Node 22: `NODE_OPTIONS=--experimental-vm-modules npx --yes --package=node@22 node node_modules/jest/bin/jest.js --runInBand`.
- `git diff --check` and Prettier validation of the updated test file pass.
- Local synthetic microbenchmark on Node 25.9.0: 20,000 lines, each containing `[link](page.md)`, median of seven runs after three warmups: 62.75 ms before, 1.21 ms after. The benchmark extracts/transpiles the old and new functions and uses a Markdown page-link regex; outputs are asserted equal for trailing-newline inputs. This measures the helper in isolation, not end-to-end CI performance.

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.
